### PR TITLE
Add agentwheel support (manifest + install docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ Start a new session and run `/context` to confirm everything is loaded. Rules an
 the user level (all projects); to scope them to one project, symlink into that repo's
 `.claude/rules/` or `.claude/skills/` instead.
 
+## Install with agentwheel
+
+[agentwheel](https://github.com/NestDevLab/agentwheel) installs this repo's rules **and** skills
+into your agent and keeps them in sync — Claude, Codex, Copilot, and other runtimes, from one
+source. This repo ships an [`openpack.json`](openpack.json) manifest, so it's a first-class
+package (requires agentwheel ≥ 0.8). Run it from where you want it installed (`~` for user level,
+or a project root):
+
+```sh
+npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude
+```
+
+Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. Add `--dry-run` to
+preview, or `--mode tracking` to follow this repo (`agentwheel update` pulls future changes).
+
+Only want specific pieces instead of everything? Select them by `<type>/<name>` — for example, one
+skill plus one rule:
+
+```sh
+npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude \
+  --select skills/run-nx-checks,rules/no-nonsense-comments.md
+```
+
+`--select` is repeatable or comma-separated.
+
 ## Install skills via skills.sh
 
 You can also use the [skills.sh](https://skills.sh/) installer to install the skills from this repo:

--- a/openpack.json
+++ b/openpack.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 2,
+  "name": "FrancescoBorzi/agent-toolkit",
+  "version": "0.1.0",
+  "provides": [
+    { "type": "rules", "path": "rules" },
+    { "type": "skills", "path": "skills" }
+  ]
+}


### PR DESCRIPTION
## What

Adds first-class [agentwheel](https://github.com/NestDevLab/agentwheel) support so this toolkit can be installed and kept in sync across multiple AI agents from one source.

- **`agentwheel.json`** — a package manifest declaring the repo's `rules/` and `skills/` as agentwheel `provides`. agentwheel already auto-detects these layouts, but an explicit manifest gives the package a stable name/version and makes it a first-class install target.
- **README** — a new "Install with agentwheel" section documenting `agentwheel add github:FrancescoBorzi/agent-toolkit --adapter <claude|codex|copilot|...>` followed by `agentwheel sync`.

## Why

agentwheel weaves the same skills and rules into each runtime's native location (Claude, Codex, Copilot, and others) and keeps them in sync, complementing the existing `install.sh` symlink flow and `skills.sh` installer.

## Scope

Purely additive — `install.sh`, the `skills.sh` flow, and all existing rules/skills are untouched.