### PR TITLE
[codex] Update agentwheel OpenPack metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Toolkit Guide
+
+On this repo I keep all my personal rules and skills for Claude Code and other agents, so I can
+reuse them across projects and share them with the community.
+
+The general rule here is that everything is self-contained and generic enough to be reusable in any
+project, so avoid project-specific logic or assumptions.
+
+When writing or editing Markdown documents, wrap lines at the `max_line_length` set in
+`.editorconfig`. This applies to prose; never break code blocks, tables, URLs, or links to satisfy
+it.
+
+When changing skills, rules, manifests, install behavior, or repository conventions, keep the
+documentation updated in the same change. Update `README.md`, `AGENTS.md`, and any affected
+artifact documentation so a fresh agent session can understand the current behavior without prior
+conversation context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,1 @@
-On this repo I keep all my personal rules and skills for Claude Code (and potentially other agents
-as well), so I can reuse them across projects and share them with the community.
-
-The general rule here is that everything is self-contained and generic enough to be reusable in any
-project, so avoid project-specific logic or assumptions.
-
-When writing or editing Markdown documents, wrap lines at the `max_line_length` set in
-`.editorconfig`. This applies to prose; never break code blocks, tables, URLs, or links to satisfy
-it.
+Read [`AGENTS.md`](AGENTS.md) for the repository instructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Read [`AGENTS.md`](AGENTS.md) for the repository instructions.
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ the user level (all projects); to scope them to one project, symlink into that r
 [agentwheel](https://github.com/NestDevLab/agentwheel) installs this repo's rules **and** skills
 into your agent and keeps them in sync — Claude, Codex, Copilot, and other runtimes, from one
 source. This repo ships an [`openpack.json`](openpack.json) manifest, so it's a first-class
-package (requires agentwheel ≥ 0.8). Run it from where you want it installed (`~` for user level,
-or a project root):
+OpenPack package (requires agentwheel ≥ 0.9.0). Run it from where you want it installed (`~` for
+user level, or a project root):
 
 ```sh
 npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude
@@ -78,6 +78,10 @@ npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude \
 ```
 
 `--select` is repeatable or comma-separated.
+
+The manifest also marks hard internal dependencies. For example, selecting `skills/self-improve`
+also installs `skills/compact-skill-creator`, and selecting
+`rules/self-improve-on-correction.md` also installs `skills/self-improve`.
 
 ## Install skills via skills.sh
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ The manifest also marks hard internal dependencies. For example, selecting `skil
 also installs `skills/compact-skill-creator`, and selecting
 `rules/self-improve-on-correction.md` also installs `skills/self-improve`.
 
+## Artifact relationships
+
+Some skills and rules form a workflow or rely on each other. Hard dependencies are encoded in
+[`openpack.json`](openpack.json); suggested next steps remain documented in the skill text.
+
+```mermaid
+flowchart TD
+  fetch_ticket["fetch-ticket"] --> refine["refine-ticket"]
+  fetch_pr["fetch-pr-review"] --> refine
+  refine --> manual["create-manual-test-instructions"]
+  refine --> plan["create-implementation-plan"]
+
+  self_rule["self-improve-on-correction rule"] --> self["self-improve"]
+  self --> compact["compact-skill-creator"]
+
+  plans_rule["plans-directory rule"] -. informs .-> fetch_ticket
+  plans_rule -. informs .-> fetch_pr
+  plans_rule -. informs .-> refine
+  plans_rule -. informs .-> manual
+  plans_rule -. informs .-> plan
+
+  docs_rule["self-contained-docs rule"] -. informs .-> fetch_ticket
+  docs_rule -. informs .-> fetch_pr
+  docs_rule -. informs .-> refine
+  docs_rule -. informs .-> manual
+  docs_rule -. informs .-> plan
+```
+
 ## Install skills via skills.sh
 
 You can also use the [skills.sh](https://skills.sh/) installer to install the skills from this repo:

--- a/openpack.json
+++ b/openpack.json
@@ -3,7 +3,23 @@
   "name": "FrancescoBorzi/agent-toolkit",
   "version": "0.1.0",
   "provides": [
-    { "type": "rules", "path": "rules" },
-    { "type": "skills", "path": "skills" }
+    {
+      "type": "rules",
+      "path": "rules",
+      "items": {
+        "self-improve-on-correction.md": {
+          "requires": ["skills/self-improve"]
+        }
+      }
+    },
+    {
+      "type": "skills",
+      "path": "skills",
+      "items": {
+        "self-improve": {
+          "requires": ["skills/compact-skill-creator"]
+        }
+      }
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- update the agentwheel install docs to require agentwheel >= 0.9.0
- declare hard OpenPack item dependencies for self-improvement artifacts
- document the selective install dependency behavior in the README

## Validation
- npm view agentwheel version dist-tags --json
- npx --yes agentwheel list ./yehonal/agent-toolkit
- npx --yes agentwheel package validate /home/administrator/env/workspace/itermodus/yehonal/agent-toolkit
- npx --yes agentwheel plan /home/administrator/env/workspace/itermodus/yehonal/agent-toolkit --adapter codex --target-root /tmp/agent-toolkit-agentwheel-check --only-source --select skills/self-improve
- npx --yes agentwheel plan /home/administrator/env/workspace/itermodus/yehonal/agent-toolkit --adapter codex --target-root /tmp/agent-toolkit-agentwheel-check-rule --only-source --select rules/self-improve-on-correction.md
- git diff --check