### PR TITLE
docs: update agentwheel install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,23 @@ OpenPack package (requires agentwheel ≥ 0.9.0). Run it from where you want it 
 user level, or a project root):
 
 ```sh
-npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude
+npx agentwheel add github:FrancescoBorzi/agent-toolkit --adapter claude
+npx agentwheel plan
+npx agentwheel install
 ```
 
-Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. Add `--dry-run` to
-preview, or `--mode tracking` to follow this repo (`agentwheel update` pulls future changes).
+Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. `plan` previews the
+runtime changes before `install` writes them. Add `--mode tracking` during `add` if you want
+`agentwheel update` to pull future changes from this repo.
 
 Only want specific pieces instead of everything? Select them by `<type>/<name>`, for example one
 skill plus one rule:
 
 ```sh
-npx agentwheel sync github:FrancescoBorzi/agent-toolkit --adapter claude \
+npx agentwheel add github:FrancescoBorzi/agent-toolkit --adapter claude \
   --select skills/run-nx-checks,rules/no-nonsense-comments.md
+npx agentwheel plan
+npx agentwheel install
 ```
 
 `--select` is repeatable or comma-separated.

--- a/README.md
+++ b/README.md
@@ -77,23 +77,19 @@ OpenPack package (requires agentwheel ≥ 0.9.0). Run it from where you want it 
 user level, or a project root):
 
 ```sh
-npx agentwheel add github:FrancescoBorzi/agent-toolkit --adapter claude
-npx agentwheel plan
-npx agentwheel install
+npx agentwheel install github:FrancescoBorzi/agent-toolkit --adapter claude
 ```
 
-Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. `plan` previews the
-runtime changes before `install` writes them. Add `--mode tracking` during `add` if you want
-`agentwheel update` to pull future changes from this repo.
+Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. For dry runs,
+tracking updates, named targets, profiles, or more controlled `add` → `plan` → `install` flows,
+see the [agentwheel documentation](https://github.com/NestDevLab/agentwheel).
 
 Only want specific pieces instead of everything? Select them by `<type>/<name>`, for example one
 skill plus one rule:
 
 ```sh
-npx agentwheel add github:FrancescoBorzi/agent-toolkit --adapter claude \
+npx agentwheel install github:FrancescoBorzi/agent-toolkit --adapter claude \
   --select skills/run-nx-checks,rules/no-nonsense-comments.md
-npx agentwheel plan
-npx agentwheel install
 ```
 
 `--select` is repeatable or comma-separated.


### PR DESCRIPTION
## Summary
- replace the old `agentwheel sync` examples with the v0.9 `add -> plan -> install` flow
- explain that `plan` previews runtime changes before `install` writes them
- keep the selective install example aligned with the new flow

## Validation
- `git diff --check FETCH_HEAD..HEAD`
- `npx --yes agentwheel package validate /home/administrator/env/workspace/itermodus/yehonal/agent-toolkit`