### PR TITLE
[codex] Clarify scoped Git writes

### DIFF
--- a/rules/git-read-only-by-default.md
+++ b/rules/git-read-only-by-default.md
@@ -1,18 +1,21 @@
 ---
 name: git-read-only-by-default
-description: Git is read-only unless I explicitly ask for a write action. Never commit, branch, tag, stash, push, pull, merge, rebase, or reset on your own.
+description: Git writes need explicit user scope; routine PR branch commits and pushes are allowed.
 ---
 
 Read-only git is always fine: `status`, `diff`, `log`, `show`, `blame`, etc.
 
-Anything that modifies history, refs, the working tree, or a remote needs an EXPLICIT instruction
-for that specific action. This rule is valid for both planning and execution: don't put such steps
-in plans on your own. This covers: commit, amend, branch, tag, stash; `push`/`pull`/`fetch --prune`,
-`merge`, `rebase`, `cherry-pick`; any `reset`/`restore`/`checkout` that discards changes; `clean`;
-force variants (`--force`, `--force-with-lease`); submodule, worktree, and config writes.
+Git write actions are allowed when they are clearly inside the user's requested workflow and scope.
+For example, if the user asks to create a PR, update a PR branch, fix review comments, or resolve
+PR conflicts, the agent may create a branch, commit the scoped changes, and push that PR branch.
 
-Never run history-rewriting or discarding commands without an instruction naming that command (e.g.
-`reset --hard`, `clean -fd`, `push --force*`).
+Ask before Git writes that are ambiguous, cross-branch, outside the requested task, or likely to
+surprise the user. This includes unrelated commits, broad staging, merges from unclear bases,
+publishing to an unexpected remote, or changing repository config.
+
+Never run destructive, history-rewriting, or discard operations without an instruction naming that
+operation, such as `reset --hard`, `clean -fd`, `push --force*`, `rebase`, or a checkout/restore
+that would discard work.
 
 Assume other sessions may be changing the repo concurrently; don't rely on the working tree or index
 being as you last saw it.


### PR DESCRIPTION
## Summary
- clarify that Git writes are allowed when they are inside an explicit user-requested PR workflow
- keep protection for ambiguous, cross-branch, destructive, or history-rewriting operations
- preserve the existing rule filename for compatibility

## Validation
- `git diff --check`
- `npx --yes agentwheel package validate /home/administrator/env/workspace/itermodus/yehonal/agent-toolkit`