### PR TITLE
feat(self-improve): propose creating new skills/docs if no good candidate exists

### DIFF
--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep
 license: MIT
 metadata:
   author: Francesco Borzì
-  version: "1.1"
+  version: "1.2"
 ---
 
 # Self-improve
@@ -46,8 +46,9 @@ Whenever unsure whether it generalizes, ask the user.
 1. **Capture the lesson.** State, in one line, the general rule the feedback implies — not the
    surface incident ("Mock external HTTP in unit tests," not "the agent mocked the wrong call").
 2. **Locate the target.** Find which skill/doc governs this action (search skills, `AGENTS.md`/
-   `CLAUDE.md`, convention docs). If one exists, it's the target. If none does and the lesson is
-   broad, propose the most fitting doc (or, with the user, a new one). Ask whenever unsure.
+   `CLAUDE.md`, convention docs). If one exists, it's the target. If no existing skill/doc fits and
+   the lesson implies a recurring workflow, propose creating a new skill and ask before drafting it.
+   If the lesson is broad but not skill-shaped, propose the most fitting doc. Ask whenever unsure.
 3. **Draft the edit.** Write the rule into the target as the least text that fully captures it:
    agent-agnostic ("the agent", never a vendor name), no process narration, no restating — a real
    durable instruction. Prefer tightening or extending an existing rule over appending a new one.

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: self-improve
-description: Capture user feedback into the skill or governing doc (SKILL.md, AGENTS.md/CLAUDE.md, coding-standards, etc.) that should have prevented a mistake, so future sessions don't repeat it. Use when the user rejects, reverts, or overrides the agent's output or approach on something a skill or governing doc covers (or should), and when manually invoked to improve a skill/doc.
+description: Capture durable user feedback into the governing skill/doc, or propose creating a new skill when no suitable one exists, so future sessions don't repeat the mistake. Use when the user rejects, reverts, or overrides the agent's output or approach on something a skill/doc covers or should cover, and when manually invoked to improve or create guidance.
 allowed-tools: Read, Write, Edit, Glob, Grep
 license: MIT
 metadata:
   author: Francesco Borzì
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Self-improve


### PR DESCRIPTION
## Summary

Updates self-improve so, when no existing skill or doc fits a recurring workflow lesson, the agent proposes creating a new skill and asks before drafting it.

## Why

Recent feedback showed that some durable corrections should become new skills instead of being forced into a loosely related existing doc.

## Validation

- git diff --check
- word count checked with wc -w skills/self-improve/SKILL.md

## Note

Head branch: Yehonal:codex/self-improve-skill-creation-fork.