### PR TITLE
Declare OpenPack rule runtimes

### DIFF
--- a/openpack.json
+++ b/openpack.json
@@ -6,6 +6,8 @@
     {
       "type": "rules",
       "path": "rules",
+      "format": "markdown-rule",
+      "runtimes": ["claude", "copilot"],
       "items": {
         "self-improve-on-correction.md": {
           "requires": ["skills/self-improve"]


### PR DESCRIPTION
## Summary
- mark the `rules` OpenPack provider as `markdown-rule`
- limit those Markdown rules to Claude/Copilot runtimes so Codex installs skip them instead of failing format validation

## Validation
- `git diff --check`
- `agentwheel scan /home/administrator/env/workspace/itermodus/joseph-yehonal/agent-toolkit`
- `agentwheel install /home/administrator/env/workspace/itermodus/joseph-yehonal/agent-toolkit --adapter codex --local --dry-run`
- `agentwheel install /home/administrator/env/workspace/itermodus/joseph-yehonal/agent-toolkit --adapter claude --local --dry-run`