### PR TITLE
Add cross-harness self-improve activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,9 @@ Frame rules and skills as agent-agnostic: describe what they do, not as "for Cla
 specific agent. Install instructions may still reference agent-specific paths (e.g.
 `~/.claude/skills/`), since that's the install mechanism, not how the content is framed.
 
+When adding cross-runtime Agentwheel support, target runtimes in `openpack.json` by the artifact
+type they consume instead of duplicating the same behavior in unsupported runtime locations.
+
 When writing or editing Markdown documents, wrap lines at the `max_line_length` set in
 `.editorconfig`. This applies to prose; never break code (fenced blocks or inline backtick
 spans — a command must stay on one line even past the limit), tables, URLs, links, or YAML

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A collection of project-agnostic, generic agentic tools for common engineering t
 
 Designed to work with any kind of AI agent on any kind of software development project.
 
+This repo ships skills, rules, and cross-runtime instructions composed from
+[`fragments/`](fragments) for agents that do not consume rule files directly.
+
 ## Skills
 
 Agentic skills I use across all my software engineering projects — solo or in a team.
@@ -171,6 +174,10 @@ Swap `--adapter claude` for `codex`, `copilot`, etc. to target other agents. For
 tracking updates, named targets, profiles, or more controlled `add` → `plan` → `install` flows,
 see the [agentwheel documentation](https://github.com/NestDevLab/agentwheel).
 
+The manifest targets the artifact type each runtime actually consumes: Claude and Copilot receive
+the `rules/` artifacts, while Codex, OpenClaw, and Hermes receive composed `instructions/AGENTS.md`
+content for the same self-improvement activation behavior.
+
 Only want specific pieces instead of everything? Select them by `<type>/<name>`, for example one
 skill plus one rule:
 
@@ -218,6 +225,7 @@ flowchart TD
   refine --> plan["create-implementation-plan"]
 
   self_rule["self-improve-on-correction rule"] --> self["self-improve"]
+  self_instructions["self-improve activation instructions"] --> self
   self --> compact["compact-skill-creator"]
   self --> compact_docs["compact-docs-writer"]
   compact --> compact_docs

--- a/fragments/self-improve-activation.md
+++ b/fragments/self-improve-activation.md
@@ -1,0 +1,9 @@
+# Self-Improvement Activation
+
+When the user corrects, reverts, or overrides an action under standing guidance, or when a repeated
+workflow looks worth turning into reusable guidance, finish the current task and then offer to
+invoke `self-improve`.
+
+Use it for durable, recurring lessons only: skill/doc improvements, missing or too-narrow rules, and
+repeated operations that should become a skill. If no existing target fits, propose a new skill or
+doc. Suggest only; do not edit guidance without explicit approval.

--- a/instructions/AGENTS.md
+++ b/instructions/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Toolkit Instructions
+
+<!-- openpack:include fragments/self-improve-activation.md -->

--- a/openpack.json
+++ b/openpack.json
@@ -4,6 +4,20 @@
   "version": "0.1.0",
   "provides": [
     {
+      "type": "instructions",
+      "path": "instructions/AGENTS.md",
+      "runtimes": ["codex", "openclaw", "hermes"],
+      "items": {
+        "AGENTS.md": {
+          "compose": [
+            {
+              "include": "fragments/self-improve-activation.md"
+            }
+          ]
+        }
+      }
+    },
+    {
       "type": "rules",
       "path": "rules",
       "format": "markdown-rule",
@@ -34,6 +48,10 @@
           "requires": ["skills/fetch-ticket"]
         }
       }
+    },
+    {
+      "type": "fragments",
+      "path": "fragments"
     }
   ]
 }

--- a/rules/self-improve-on-correction.md
+++ b/rules/self-improve-on-correction.md
@@ -1,9 +1,12 @@
 ---
 name: self-improve-on-correction
-description: When corrected on something a skill or doc governs, offer to persist the fix via /self-improve.
+description: When corrected on durable guidance, or when a repeated workflow should become guidance, offer /self-improve.
 ---
 
 When the user corrects, reverts, or overrides something the agent did under a skill or governing
 doc (SKILL.md, AGENTS.md/CLAUDE.md, conventions, rules) — and the lesson generalizes — note it,
 finish the current task, then at the next natural breakpoint invoke `/self-improve` to suggest
-persisting it. Suggest only; apply nothing without explicit approval.
+persisting it.
+
+Also invoke `/self-improve` when a repeated workflow or obvious guidance gap appears skill-shaped
+but is not yet covered. Suggest only; apply nothing without explicit approval.

--- a/skills/self-improve/SKILL.md
+++ b/skills/self-improve/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep
 license: MIT
 metadata:
   author: Francesco Borzì
-  version: "1.9"
+  version: "1.10"
 ---
 
 # Self-improve
@@ -39,6 +39,8 @@ coding-standards or convention doc, a rules file — anything that guides future
   [compact-docs-writer](../compact-docs-writer/SKILL.md). Actually invoke the skill and follow its
   workflow *before* drafting or applying; reading it, applying its principles by hand, or naming it
   after a direct edit does not count.
+- **Generated output is not source.** When a manager owns an installed skill or doc, locate and
+  change its source package; do not patch the generated runtime copy.
 
 ## Recognize a persistable correction (self-trigger)
 


### PR DESCRIPTION
## Summary

- add an Agentwheel instructions artifact for Codex, OpenClaw, and Hermes
- factor the shared self-improvement activation text into a reusable fragment
- broaden the Claude/Copilot self-improve rule to cover repeated workflows that should become guidance
- document how the manifest targets each runtime artifact type

## Why

The existing rule artifact is correctly targeted at Claude/Copilot, but runtimes that do not consume rules skip it. They can still receive the self-improve skill, but they miss the behavioral instruction that tells the agent when to offer it automatically. This adds that activation path through instructions without duplicating it into Claude rule locations.

## Validation

- `agentwheel scan .`
- `agentwheel list .`
- `agentwheel list . --select instructions/AGENTS.md --select rules/self-improve-on-correction.md --select skills/self-improve`
- `agentwheel package validate .`
- dry-run checks for Claude and Codex/OpenClaw/Hermes targeting showed the rule skipped outside Claude/Copilot and the instruction selected for non-rule runtimes
