### PR TITLE
chore: add .gitattributes to enforce LF endings on shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF line endings regardless of platform
+*.sh text eol=lf


### PR DESCRIPTION
## What

Add a `.gitattributes` file declaring `*.sh text eol=lf`.

## Why

Shell scripts require LF line endings. Without an in-repo policy, line endings depend on each contributor's local `core.autocrlf` setting, which Git for Windows enables by default. With `autocrlf=true`, `install.sh` gets checked out with CRLF, and bash (including under Cygwin/MSYS on Windows) fails to run it.

Declaring the line-ending policy in `.gitattributes` makes shell scripts check out with LF for everyone, regardless of their client configuration, instead of relying on every contributor to configure their environment correctly.

## Notes

- `install.sh` is already stored with LF in the repo, so this only enforces correct checkout behavior going forward.
- Existing local clones may need `git add --renormalize .` (or a fresh checkout) to pick up the corrected line endings.