### PR TITLE
feat: new handover skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ fetch a ticket, refine it, plan it, then let a fresh session execute it.
   decisions together, then save it for a fresh session to execute.
 - **[create-manual-test-instructions](./skills/create-manual-test-instructions/SKILL.md)** —
   derive manual test steps from a ticket or requirements file, useful for the developer or QA.
+- **[handover](./skills/handover/SKILL.md)** — package a finished change for its reviewers:
+  intent, decisions and plan deviations with sources, real test evidence, and a review guide —
+  paste-ready as the PR description.
 
 ### Review assistants
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ fetch a ticket, refine it, plan it, then let a fresh session execute it.
 - **[create-manual-test-instructions](./skills/create-manual-test-instructions/SKILL.md)** —
   derive manual test steps from a ticket or requirements file, useful for the developer or QA.
 - **[handover](./skills/handover/SKILL.md)** — package a finished change for its reviewers:
-  intent, decisions and plan deviations with sources, real test evidence, and a review guide —
-  paste-ready as the PR description.
+  what it does and why, the decisions and plan deviations worth knowing, real test evidence, and
+  a review guide — paste-ready as the PR description.
 
 ### Review assistants
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ flowchart TD
   check_impl["check-ticket-implementation"] --> fetch_ticket
   refine --> manual["create-manual-test-instructions"]
   refine --> plan["create-implementation-plan"]
+  plan --> handover["handover"]
+  handover --> express
 
   self_rule["self-improve-on-correction rule"] --> self["self-improve"]
   self --> compact["compact-skill-creator"]
@@ -194,6 +196,7 @@ flowchart TD
   plans_rule -. informs .-> plan
   plans_rule -. informs .-> review_ticket
   plans_rule -. informs .-> check_impl
+  plans_rule -. informs .-> handover
 
   docs_rule["self-contained-docs rule"] -. informs .-> fetch_ticket
   docs_rule -. informs .-> fetch_pr

--- a/openpack.json
+++ b/openpack.json
@@ -47,6 +47,9 @@
         },
         "check-ticket-implementation": {
           "requires": ["skills/fetch-ticket"]
+        },
+        "handover": {
+          "requires": ["skills/use-conversational-language"]
         }
       }
     }

--- a/skills/create-implementation-plan/SKILL.md
+++ b/skills/create-implementation-plan/SKILL.md
@@ -4,7 +4,7 @@ description: Turn a refined requirements document into a structured implementati
 license: MIT
 metadata:
   author: Francesco Borzì
-  version: "1.7"
+  version: "1.8"
 ---
 
 # Create Implementation Plan
@@ -78,7 +78,7 @@ Create the file in the **same directory as the requirements document**, named by
 `.REQUIREMENTS` with `.PLAN` (e.g. `FOO.REQUIREMENTS.md` → `FOO.PLAN.md`). If the input doesn't
 follow that convention, append `.PLAN` before `.md`.
 
-Structure — four parts:
+Structure — five parts:
 
 1. **Summary** — 1–3 sentences: what this plan implements and the overall shape of the change (which
    areas are touched).
@@ -108,6 +108,10 @@ Structure — four parts:
    requirements' AC section. If unnumbered, number them (`AC-1`, …). Each references the step
    number(s) that satisfy it (e.g. "AC-3 → steps 4, 7"). Note any AC that needs manual verification
    only. The execution session uses this as its done-check.
+5. **Decisions log** — a standing instruction copied into the plan for the execution session:
+   "When a settled decision deviates from or extends this plan, append one line — the decision
+   and its why — to `<slug>.DECISIONS.md` beside this plan, the moment it's settled." Without
+   it, the why behind mid-implementation pivots is lost to later handover and review.
 
 The plan must capture **all the thinking** — every decision needed to implement the feature, so the
 execution session re-derives nothing. It may omit only mechanical, locally-reversible detail with no

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -36,7 +36,8 @@ item is matched.
 State a "why" only where a source gives it. A deviation nothing explains is asked of the author
 once; unanswered or unaskable, it ships flagged in plain words ("nothing records why — worth
 confirming"), since it may be an unintentional gap rather than a decision. Sourcing is your gate,
-not the reviewer's reading: it decides what you may write, and never appears in the text.
+not the reviewer's reading: it decides what you may write, and never appears in the text. 
+When not sure, always ask. Never guess.
 
 ## The artifact
 

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: handover
+description: Use when handing finished work over to code review — writing a PR description, opening a PR, or packaging a change for review by a human, an agent, or both.
+license: MIT
+metadata:
+  author: Stefanos Lignos
+  version: "0.1"
+---
+
+# Handover
+
+Package a finished change for its reviewers so they never reconstruct intent from the diff. The
+handover is **claims to verify, not advocacy** — every statement points at something the reviewer
+can check.
+
+## Sources
+
+Collect before writing, in order, skipping what doesn't exist:
+
+1. **Decisions log** — a `*.DECISIONS.md` beside the task's plan.
+2. **Planning docs** — the task's requirements, plan, and ticket in the project's planning
+   directory.
+3. **The session** — when this session produced the change: decisions, pivots, and constraints
+   from the conversation itself.
+4. **Git history and the diff** — the branch's commits and its full diff against the target.
+
+Match the diff against plan and requirements both ways — planned but absent, present but
+unplanned — and every divergence joins the delta section. Done when every source was read or
+confirmed absent and every planned item is matched against the diff.
+
+## The source rule
+
+Every reported decision or deviation names its source — log, doc, session, or the author's
+answer. Never invent rationale. A deviation no source explains is asked of the author once;
+unanswered or unaskable, it appears as "unexplained — confirm before merge", since it may be an
+unintentional gap, not a decision.
+
+## Evidence
+
+Run the project's own checks (tests, lint, build — whatever it defines) and capture the real
+output; describing what the tests cover is not evidence. State just as plainly what was **not**
+verified — untested paths, unmet or unchecked acceptance criteria, manual steps not performed.
+
+## The artifact
+
+`<slug>.HANDOVER.md` beside the task's plan; no planning directory → present the content and ask
+where to save it. The body is paste-ready as the PR description — before drafting it, actually
+invoke use-conversational-language; reciting its rules from memory does not count. Sections, in
+order, skipped only when truly empty:
+
+1. **Intent** — what the change is for and why, a few lines; link the ticket/requirements rather
+   than restate them.
+2. **Decisions & delta** — review-relevant decisions and every plan divergence, one line each:
+   claim, source, where to verify. Review-relevant means a competent reviewer given diff and docs
+   would otherwise flag it as wrong or waste time re-deriving it; everything else stays out.
+3. **Evidence** — commands actually run with real results, then what was not verified.
+4. **Review guide** — the few files where human judgment matters and why, the mechanical rest,
+   and a reading order.
+5. **Prior review** — reviews already performed (agent or human), each finding's fate; "none" is
+   written out, never omitted.
+6. **Limitations & assumptions** — known shortcomings, assumptions, open questions.
+
+Done when every section is filled or knowingly skipped, every claim names its source, and nothing
+reads as verified that wasn't.
+
+## Boundaries
+
+- Modify no source files; the handover doc is the only file written.
+- Never push, or open/comment on a PR — publishing is the user's explicit call.
+- The project's own checks are in scope to run; anything beyond (deploys, migrations, data jobs)
+  is not.

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -9,59 +9,61 @@ metadata:
 
 # Handover
 
-Package a finished change for its reviewers so they never reconstruct intent from the diff. The
-handover is **claims to verify, not advocacy** — every statement points at something the reviewer
-can check.
+Package a finished change so its reviewers never reconstruct intent from the diff. Write for a
+reviewer holding the diff and nothing else — no planning docs, no session, no knowledge that
+either exists.
 
-## Sources
+## Gather
 
-Collect before writing, in order, skipping what doesn't exist:
+Start the project's checks (tests, lint, build — whatever it defines) first, unless this session
+already ran them on this tree; read these while they run, skipping what doesn't exist:
 
 1. **Decisions log** — a `*.DECISIONS.md` beside the task's plan.
 2. **Planning docs** — the task's requirements, plan, and ticket in the project's planning
    directory.
-3. **The session** — when this session produced the change: decisions, pivots, and constraints
-   from the conversation itself.
-4. **Git history and the diff** — the branch's commits and its full diff against the target.
+3. **The session**, when it produced the change: decisions, pivots, constraints.
+4. **The diff** against the target, plus commit subjects.
 
-Match the diff against plan and requirements both ways — planned but absent, present but
-unplanned — and every divergence joins the delta section. Done when every source was read or
-confirmed absent and every planned item is matched against the diff.
+Each source once, no deeper than the artifact needs: skim the diff whole, deep-read only the files
+you will name in the *Review guide*, and never rebuild history commit by commit — which commit
+changed what is the diff's job, not yours.
 
-## The source rule
+Then match the plan's steps and acceptance criteria against the diff both ways — planned but
+absent, present but unplanned. Done when every source is read or confirmed absent and every planned
+item is matched.
 
-Every reported decision or deviation names its source — log, doc, session, or the author's
-answer. Never invent rationale. A deviation no source explains is asked of the author once;
-unanswered or unaskable, it appears as "unexplained — confirm before merge", since it may be an
-unintentional gap, not a decision.
+## Never invent rationale
 
-## Evidence
-
-Run the project's own checks (tests, lint, build — whatever it defines) and capture the real
-output; describing what the tests cover is not evidence. State just as plainly what was **not**
-verified — untested paths, unmet or unchecked acceptance criteria, manual steps not performed.
+State a "why" only where a source gives it. A deviation nothing explains is asked of the author
+once; unanswered or unaskable, it ships flagged in plain words ("nothing records why — worth
+confirming"), since it may be an unintentional gap rather than a decision. Sourcing is your gate,
+not the reviewer's reading: it decides what you may write, and never appears in the text.
 
 ## The artifact
 
 `<slug>.HANDOVER.md` beside the task's plan; no planning directory → present the content and ask
-where to save it. The body is paste-ready as the PR description — before drafting it, actually
-invoke use-conversational-language; reciting its rules from memory does not count. Sections, in
-order, skipped only when truly empty:
+where to save it. Its body is paste-ready as the PR description, and stands alone:
 
-1. **Intent** — what the change is for and why, a few lines; link the ticket/requirements rather
-   than restate them.
-2. **Decisions & delta** — review-relevant decisions and every plan divergence, one line each:
-   claim, source, where to verify. Review-relevant means a competent reviewer given diff and docs
-   would otherwise flag it as wrong or waste time re-deriving it; everything else stays out.
-3. **Evidence** — commands actually run with real results, then what was not verified.
-4. **Review guide** — the few files where human judgment matters and why, the mechanical rest,
-   and a reading order.
-5. **Prior review** — reviews already performed (agent or human), each finding's fate; "none" is
-   written out, never omitted.
-6. **Limitations & assumptions** — known shortcomings, assumptions, open questions.
+- **Mention only what the reviewer can open** — a tracker URL, or a file you verified is committed
+  on the branch. Everything else — planning docs, decisions log, session, commit hashes — is
+  neither linked nor named: write what it says ("this was meant to …"), never where it says it.
+- **Under a screen**, ~400 words; the caps below are limits, not targets.
+- **Plain reviewer-facing wording**, never this skill's vocabulary. Before drafting, actually
+  invoke use-conversational-language — reciting its rules from memory does not count.
 
-Done when every section is filled or knowingly skipped, every claim names its source, and nothing
-reads as verified that wasn't.
+Sections, skipped only when truly empty:
+
+1. **What and why** — 2–3 lines.
+2. **Decisions worth knowing** — at most 5 lines, each: what was chosen or what departs from the
+   plan, its why or the missing-why flag, and where in the code to see it.
+3. **Testing** — commands actually run with their real output, then what was **not** verified —
+   untested paths, unmet or unchecked acceptance criteria, manual steps skipped. Describing what
+   the tests cover is not evidence.
+4. **Review guide** — the few files where judgment matters and why; the rest named as mechanical.
+5. **Known gaps** — at most 3: shortcomings, assumptions, open questions.
+
+Done when every section is filled or knowingly skipped, nothing reads as verified that wasn't, and
+nothing in the text points at something the reviewer cannot open.
 
 ## Boundaries
 

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handover
-description: Use when handing finished work over to code review — writing a PR description, opening a PR, or packaging a change for review by a human, an agent, or both.
+description: Use when handing finished work over to code review — writing a PR description or packaging a change for review by a human, an agent, or both.
 license: MIT
 metadata:
   version: "0.1"
@@ -40,7 +40,7 @@ not the reviewer's reading: it decides what you may write, and never appears in 
 
 ## The artifact
 
-`<slug>.HANDOVER.md` beside the task's plan; no planning directory → present the content and ask
+`<slug>.HANDOVER.md` beside the task's plan; if no planning directory → present the content and ask
 where to save it. Its body is paste-ready as the PR description, and stands alone:
 
 - **Mention only what the reviewer can open** — a tracker URL, or a file you verified is committed

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -3,7 +3,6 @@ name: handover
 description: Use when handing finished work over to code review — writing a PR description, opening a PR, or packaging a change for review by a human, an agent, or both.
 license: MIT
 metadata:
-  author: Stefanos Lignos
   version: "0.1"
 ---
 


### PR DESCRIPTION
# Add the handover skill

## What and why

Adds a `handover` skill that packages a finished change for its reviewers: what it does and why,
the decisions worth knowing, real test evidence, and a guide to the files where judgment matters.
The doc it produces is paste-ready as a PR description. The goal is that reviewers stop
reconstructing intent from the diff, and that nothing outside the diff is assumed available to
them.

It also extends `create-implementation-plan` so plans carry a standing instruction to log decisions
the moment they're settled, which is what handover reads back later.