### PR TITLE
feat: new self-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Review helpers that check the codebase while assisting with code or ticket revie
   or not done in a human-readable status report.
 - **[fresh-eyes-review](./skills/fresh-eyes-review/SKILL.md)** — let an agent with a fresh
   perspective review a changeset and report its findings back to the main session.
+- **[self-review](./skills/self-review/SKILL.md)** — get your changeset merge-ready before
+  requesting review: a fresh-context reviewer checks it as a maintainer would, you answer every
+  finding, and a compact report for the PR proves the review happened.
+  Projects can tune the review via an optional `.agents/docs/self-review-rules.md`.
 
 ### Code checks
 
@@ -167,6 +171,7 @@ flowchart TD
   refine_pr --> plan
   refine_pr --> express["use-conversational-language"]
   review_code["review-code-assistant"] --> express
+  self_review["self-review"] --> fresh_eyes["fresh-eyes-review"]
   realistic_rule["write-realistic-texts rule"] --> express
   nonsense_rule["no-nonsense-comments rule"] --> express
   review_ticket["review-ticket"] --> fetch_ticket
@@ -195,6 +200,7 @@ flowchart TD
   plans_rule -. informs .-> review_ticket
   plans_rule -. informs .-> check_impl
   plans_rule -. informs .-> handover
+  plans_rule -. informs .-> self_review
 
   docs_rule["self-contained-docs rule"] -. informs .-> fetch_ticket
   docs_rule -. informs .-> fetch_pr

--- a/openpack.json
+++ b/openpack.json
@@ -50,6 +50,9 @@
         },
         "handover": {
           "requires": ["skills/use-conversational-language"]
+        },
+        "self-review": {
+          "requires": ["skills/fresh-eyes-review"]
         }
       }
     }

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -33,7 +33,7 @@ what/why belongs to the PR description (e.g. via /handover), never here.
    ships unreviewed later; any that do belong, the author commits before proceeding. Only the
    report this skill writes is exempt from both checks.
 3. `git fetch` the target's remote (local-only target → nothing to fetch; a failed fetch → say
-   so and ask rather than diff stale refs), then diff `<target>...HEAD` (merge-base three-dot).
+   so and ask rather than diff stale refs), then diff `<target>...<source>` (merge-base three-dot).
    No merge base → usually a shallow clone or wrong target: deepen (`git fetch --unshallow`)
    and retry, else ask — never fall back to a two-dot diff, which presents the target's own
    commits as the author's. Empty diff → probably a wrong target (typical: a fork's default

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -21,22 +21,25 @@ what/why belongs to the PR description (e.g. via /handover), never here.
 1. Resolve source and target. No input → current branch against the auto-detected target: the
    default branch of the `upstream` remote when one exists (fork workflow), else of `origin`
    (`git symbolic-ref refs/remotes/<remote>/HEAD`), else the sole existing candidate among
-   `main`, `master`, `develop`/`development` — failure or ambiguity → ask. Explicit branches in
-   the invocation win. State the chosen target.
-2. `git fetch` the target's remote, then diff `<target>...HEAD` (merge-base three-dot; two-dot
-   only without a common ancestor). Empty diff → stop: nothing to review against the target.
-3. A working tree that isn't clean blocks the run — commit or stash first, no override: the diff
-   covers commits only, so uncommitted work would ship unreviewed under a clean report. This
-   skill's own artifacts (report, planning-home files) don't count as dirty.
+   `main`, `master`, `develop`/`development` (remote-tracking ref first, else the local branch) —
+   failure or ambiguity → ask. Explicit branches in the invocation win. State the chosen target.
+2. `git fetch` the target's remote (local-only target → nothing to fetch; a failed fetch → say
+   so and ask rather than diff stale refs), then diff `<target>...HEAD` (merge-base three-dot;
+   two-dot only without a common ancestor). Empty diff → probably a wrong target (typical: a
+   fork's default branch already holding the commits) — say so and ask for the true one.
+3. Modified tracked files block the run — commit or stash first, no override: the diff covers
+   commits only, so uncommitted work would ship unreviewed under a clean report. Untracked files
+   don't block: they can't ship unless committed. This skill's own artifacts (report,
+   planning-home files) don't count as dirty.
 
 Done when source branch, target, and reviewed SHA are recorded and the diff is non-empty.
 
 ## Project rules file
 
 `.agents/docs/self-review-rules.md`, when the project carries one, adds project-specific rules or
-overrides to the review mandate and process (extra focus areas, more reviewers, report handling) —
-never to the Boundaries below. Absent → skip silently. Either way, the report states whether it
-was found and applied.
+overrides to the review mandate and process (extra focus areas, report handling) — never to the
+Boundaries below. Absent → skip silently. Either way, the report states whether it was found and
+applied.
 
 ## Review
 
@@ -45,17 +48,20 @@ inputs all explicit, so it runs without its confirmation step — with:
 
 - an intent statement — the task's ticket or requirements when the planning home holds them, else
   derived from the branch name and commit subjects;
-- the planning home and the report as excluded paths: author rationale and past rounds'
-  dispositions must never reach the reviewer;
+- excluded paths: the planning home and the report — author rationale and past dispositions must
+  never reach the reviewer. Planning files the changeset itself touches ship in the PR, so they
+  are reviewed like any other change; the report stays excluded always;
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
   as a checklist against every changed file, not as background reading; and leftovers — debug
   prints, commented-out code, stray TODOs, accidentally committed files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
-- an instruction to the reviewer to report back the harness and model it ran on.
+- an instruction to the reviewer to report back the harness and model it ran on, and whether it
+  covered every changed file.
 
-Done when the reviewer has returned its findings — possibly none — and its provenance.
+Done when the reviewer has returned its findings — possibly none — its provenance, and its
+coverage.
 
 ## Disposition walk
 
@@ -84,13 +90,14 @@ convention (e.g. `.agents/plans/<slug>/`); reuse the slug of the task's existing
 planning home resolvable → ask where to save it. Re-runs and later rounds update the file in
 place — one file per task, never versioned copies: its destination is a single upload. It is for
 pasting into the PR description or a comment, not for committing, unless the project rules file
-says otherwise.
+says otherwise — either way committing is the author's move, never the agent's.
 
 Compact above all: one line per finding, fusing location and concrete failure; the full prose
 stays in the session. Provenance exactly as the environment reports it, `unknown` when it
-doesn't — never guessed or recalled; the reviewer's model listed only when it differs from the
-session's; skill version from this file's frontmatter, date = today. Caveats (fixes not
-re-reviewed, a same-context fallback review) are visible header lines.
+doesn't — never guessed or recalled; the reviewer's model, when it differs from the session's,
+appended to the **By** line as `review by <model>`; skill version from this file's frontmatter,
+date = today. Caveats (fixes not re-reviewed, a same-context fallback review, incomplete
+coverage) are visible header lines.
 
 ```markdown
 # Self-review — my-feature → main

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: self-review
+description: Self-review a changeset until merge-ready — a fresh-context reviewer checks it as a maintainer would, the author answers every finding, and a compact report for the PR proves the review happened.
+disable-model-invocation: true
+type: flow
+license: MIT
+metadata:
+  version: "0.1"
+---
+
+# Self-review
+
+Make a changeset merge-ready before submission — no regressions, sound code, the project's
+conventions respected — and prove it was scrutinized: a fresh-context reviewer hunts for what
+would block the merge, the author answers every finding, and a compact report — scannable by a
+maintainer in seconds — records the outcome. The report is the review record only; the change's
+what/why belongs to the PR description (e.g. via /handover), never here.
+
+## Pin the changeset
+
+1. Resolve source and target. No input → current branch against the auto-detected target: the
+   default branch of the `upstream` remote when one exists (fork workflow), else of `origin`
+   (`git symbolic-ref refs/remotes/<remote>/HEAD`), else the sole existing candidate among
+   `main`, `master`, `develop`/`development` — failure or ambiguity → ask. Explicit branches in
+   the invocation win. State the chosen target.
+2. `git fetch` the target's remote, then diff `<target>...HEAD` (merge-base three-dot; two-dot
+   only without a common ancestor). Empty diff → stop: nothing to review against the target.
+3. A working tree that isn't clean blocks the run — commit or stash first, no override: the diff
+   covers commits only, so uncommitted work would ship unreviewed under a clean report. This
+   skill's own artifacts (report, planning-home files) don't count as dirty.
+
+Done when source branch, target, and reviewed SHA are recorded and the diff is non-empty.
+
+## Project rules file
+
+`.agents/docs/self-review-rules.md`, when the project carries one, adds project-specific rules or
+overrides to the review mandate and process (extra focus areas, more reviewers, report handling) —
+never to the Boundaries below. Absent → skip silently. Either way, the report states whether it
+was found and applied.
+
+## Review
+
+Load and follow [fresh-eyes-review](../fresh-eyes-review/SKILL.md) on the pinned changeset —
+inputs all explicit, so it runs without its confirmation step — with:
+
+- an intent statement — the task's ticket or requirements when the planning home holds them, else
+  derived from the branch name and commit subjects;
+- the planning home and the report as excluded paths: author rationale and past rounds'
+  dispositions must never reach the reviewer;
+- the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
+  extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
+  as a checklist against every changed file, not as background reading; and leftovers — debug
+  prints, commented-out code, stray TODOs, accidentally committed files;
+- the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
+  redundancy — hedged speculation is out, zero findings is a valid outcome;
+- an instruction to the reviewer to report back the harness and model it ran on.
+
+Done when the reviewer has returned its findings — possibly none — and its provenance.
+
+## Disposition walk
+
+One finding at a time, recommending a disposition with a one-line why — the author decides:
+
+- **fix** — apply it to the working tree now; committing stays the author's move.
+- **dismiss** — record the author's reason, pushing once toward one a maintainer can evaluate
+  ("mirrors the existing pattern in this file", not "disagree"); if the author insists, their
+  words go in verbatim.
+
+Never drop or soften a finding: every one appears in the report with its disposition. When
+anything was fixed, offer one re-review round on the new SHA once the author has committed —
+offered, never forced, no loop; declined or left uncommitted, the report carries a "fixes not
+re-reviewed" caveat. A re-review carries dispositions forward: a re-raised finding matching a
+dismissed one keeps its dismissal, only new findings are walked, and the report lists each
+finding once. Close the walk by reminding the author to run the project's usual checks (build,
+lint, tests) before pushing — this skill never runs them.
+
+Done when every finding is dispositioned.
+
+## Report
+
+`<slug>.SELF-REVIEW.md` in the task's planning home, per the project's planning-directory
+convention (e.g. `.agents/plans/<slug>/`); reuse the slug of the task's existing artifacts
+(ticket, requirements, plan) — none → derive it from context (branch name, the changes); no
+planning home resolvable → ask where to save it. Re-runs and later rounds update the file in
+place — one file per task, never versioned copies: its destination is a single upload. It is for
+pasting into the PR description or a comment, not for committing, unless the project rules file
+says otherwise.
+
+Compact above all: one line per finding, fusing location and concrete failure; the full prose
+stays in the session. Provenance exactly as the environment reports it, `unknown` when it
+doesn't — never guessed or recalled; the reviewer's model listed only when it differs from the
+session's; skill version from this file's frontmatter, date = today. Caveats (fixes not
+re-reviewed, a same-context fallback review) are visible header lines.
+
+```markdown
+# Self-review — my-feature → main
+
+> **Outcome** 3 findings — 2 fixed, 1 dismissed — final round clean
+> **Reviewed** `abc1234` (`my-feature` vs `main`, merge-base diff — 12 files, +340 −120)
+> **By** <harness>, <model> — self-review v<version>, <date>
+> **Project rules** `.agents/docs/self-review-rules.md` not present
+
+## Round 1 — `abc1234`, 3 findings
+
+1. `src/foo.c:142` — null deref when the timer expires mid-update → **fixed**
+2. `db/updates/xyz.sql:3` — DELETE misses linked_id rows, orphans on re-run → **fixed**
+3. `src/foo.c:97` — guard duplicates the check 4 lines up → **dismissed**: mirrors the existing
+   pattern in this file, refactor out of scope
+
+## Round 2 — `def5678`, clean
+```
+
+Done when the report holds the outcome line, changeset refs with diffstat, provenance with skill
+version and date, rules-file status, and every round with its SHA and dispositioned findings.
+
+## Wrap up
+
+Print the report's project-relative path and the instruction to paste its content into the PR
+description or a comment. Done when both are printed.
+
+## Boundaries
+
+- Files written: the report, and the fixes the author approved during the walk — nothing else.
+- Read-only git plus `git fetch`; no commit, push, or PR operation — publishing is the author's.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -24,35 +24,41 @@ what/why belongs to the PR description (e.g. via /handover), never here.
    `refs/remotes/<remote>/HEAD`; that failing (e.g. offline), the sole existing candidate among
    `main`, `master`, `develop`/`development` (preferring `upstream`'s remote-tracking ref, then
    `origin`'s, then the local branch) — still ambiguous or none → ask. Explicit branches in the
-   invocation win. State the chosen target.
-2. `git fetch` the target's remote (local-only target → nothing to fetch; a failed fetch → say
-   so and ask rather than diff stale refs), then diff `<target>...HEAD` (merge-base three-dot;
-   two-dot only without a common ancestor). Empty diff → probably a wrong target (typical: a
-   fork's default branch already holding the commits) — say so and ask for the true one; it
-   needs no local ref, `git fetch <url> <branch>` works by URL.
-3. Modified tracked files block the run — commit or stash first, no override: the diff covers
-   commits only, so uncommitted work would ship unreviewed under a clean report. Untracked
-   files don't block, but list them and have the author confirm none belong to the change — a
-   forgotten `git add` ships unreviewed later; any that do belong, the author commits before
-   proceeding. Only the report this skill writes is exempt from both checks.
+   invocation win; a detached HEAD → ask which branch is under review. State the chosen target.
+2. Modified tracked files block the run — the diff covers commits only, so uncommitted work
+   would ship unreviewed under a clean report. What belongs to the change the author commits;
+   what doesn't, they stash — or confirm as deliberate local-only tweaks (build config, data
+   paths): the run proceeds, a report caveat naming those files. Untracked files don't block,
+   but list them and have the author confirm none belong to the change — a forgotten `git add`
+   ships unreviewed later; any that do belong, the author commits before proceeding. Only the
+   report this skill writes is exempt from both checks.
+3. `git fetch` the target's remote (local-only target → nothing to fetch; a failed fetch → say
+   so and ask rather than diff stale refs), then diff `<target>...HEAD` (merge-base three-dot).
+   No merge base → usually a shallow clone or wrong target: deepen (`git fetch --unshallow`)
+   and retry, else ask — never fall back to a two-dot diff, which presents the target's own
+   commits as the author's. Empty diff → probably a wrong target (typical: a fork's default
+   branch already holding the commits) — say so and ask for the true one; it needs no local
+   ref, `git fetch <url> <branch>` works by URL.
 
 Done when source branch, target, and reviewed SHA are recorded and the diff is non-empty.
 
 ## Project rules file
 
 `.agents/docs/self-review-rules.md`, when the project carries one, adds project-specific rules or
-overrides to the review mandate and process (extra focus areas, report handling) — never to the
-Boundaries below. Absent → skip silently. Either way, the report states whether it was found and
-applied.
+overrides to the review mandate and process (extra focus areas, round cap, report handling) —
+never to the Boundaries below. Absent → skip silently. Either way, the report states whether it
+was found and applied.
 
 ## Review
 
 Load and follow [fresh-eyes-review](../fresh-eyes-review/SKILL.md) on the pinned changeset —
 inputs all explicit, so it runs without its confirmation step — with:
 
-- an intent statement — the task's ticket or requirements when the planning home holds them, else
-  derived from the branch name and commit subjects; derivation yielding noise (`wip` commits,
-  opaque names) → ask the author for a one-liner, proposing a draft;
+- an intent statement — one or two sentences distilled from the task's ticket or requirements
+  when the planning home holds them, never the document itself (it carries the author rationale
+  excluded below), else derived from the branch name and commit subjects; derivation yielding
+  noise (`wip` commits, opaque names) → ask the author for a one-liner, proposing a draft.
+  Either way, state the intent used — the author must see what the change is judged against;
 - excluded paths: the planning home and the report — author rationale and past dispositions must
   never reach the reviewer. Planning files the changeset itself touches ship in the PR, so they
   are reviewed like any other change; the report stays excluded always;
@@ -77,14 +83,18 @@ One finding at a time, recommending a disposition with a one-line why — the au
   ("mirrors the existing pattern in this file", not "disagree"); if the author insists, their
   words go in verbatim.
 
-Never drop or soften a finding: every one appears in the report with its disposition. When
-anything was fixed, offer one re-review round on the new SHA once the author has committed —
-offered, never forced, no loop; declined or left uncommitted, the report carries a "fixes not
-re-reviewed" caveat, and any fix still uncommitted at report time is marked `fixed (uncommitted)`.
-A re-review carries dispositions forward: a re-raised finding matching a dismissed one keeps its
-dismissal, only new findings are walked, and the report lists each finding once.
+Never drop or soften a finding: every one appears in the report with its disposition. Anything
+fixed → the author commits (always their move) and a fresh round runs on the new SHA — fixes are
+new unreviewed code. Rounds stop when one yields nothing fixed — clean, or every new finding
+dismissed — or at the cap of 3 rounds, there to bound cost; the author can stop earlier at any
+point, or explicitly ask for rounds beyond the cap. Every fix no later round covered leaves a
+"fixes not re-reviewed" caveat in the report — including fixes left uncommitted, which are also
+marked `fixed (uncommitted)`. Dispositions carry forward across rounds: a re-raised finding
+matching a dismissed one keeps its dismissal and is not re-walked; one matching a fixed finding
+means the fix didn't hold — reopen it and walk it again. The report lists each finding once, with
+its latest disposition.
 
-Done when every finding is dispositioned.
+Done when every finding is dispositioned and a stop condition has ended the rounds.
 
 ## Report
 
@@ -93,7 +103,7 @@ convention (e.g. `.agents/plans/<slug>/`); reuse the slug of the task's existing
 (ticket, requirements, plan) — none → derive it from context (branch name, the changes); no
 planning home resolvable → default to `.agents/plans/<slug>/`, stating the choice rather than
 asking. Re-runs and later rounds update the file in place — read it first and carry its rounds
-and dispositions forward, under the re-review matching rule — one file per task, never versioned
+and dispositions forward, under the carry-forward rule — one file per task, never versioned
 copies: its destination is a single upload. It is for pasting into the PR description or a
 comment, not for committing, unless the project rules file says otherwise — either way committing
 is the author's move, never the agent's.
@@ -104,12 +114,14 @@ diffstat; history lives in the round headings. Provenance exactly as the environ
 `unknown` when it doesn't — never guessed or recalled; the reviewer's model, when it differs from
 the session's, appended to the **By** line as `review by <model>`; skill version from this file's
 frontmatter, date = today. Caveats (fixes not re-reviewed, a same-context fallback review,
-incomplete coverage naming the unreviewed files) are visible header lines.
+incomplete coverage naming the unreviewed files, modified tracked files confirmed local-only) are
+visible header lines.
 
 ```markdown
 # Self-review — my-feature → main
 
 > **Outcome** 3 findings — 2 fixed, 1 dismissed — final round clean
+> **Intent** <the intent statement the review ran against>
 > **Reviewed** `def5678` (`my-feature` vs `main`, merge-base diff — 12 files, +340 −120)
 > **By** <harness>, <model> — self-review v<version>, <date>
 > **Project rules** `.agents/docs/self-review-rules.md` not present
@@ -124,8 +136,9 @@ incomplete coverage naming the unreviewed files) are visible header lines.
 ## Round 2 — `def5678`, clean
 ```
 
-Done when the report holds the outcome line, changeset refs with diffstat, provenance with skill
-version and date, rules-file status, and every round with its SHA and dispositioned findings.
+Done when the report holds the outcome line, intent, changeset refs with diffstat, provenance
+with skill version and date, rules-file status, and every round with its SHA and dispositioned
+findings.
 
 ## Wrap up
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -19,18 +19,22 @@ what/why belongs to the PR description (e.g. via /handover), never here.
 ## Pin the changeset
 
 1. Resolve source and target. No input → current branch against the auto-detected target: the
-   default branch of the `upstream` remote when one exists (fork workflow), else of `origin`
-   (`git symbolic-ref refs/remotes/<remote>/HEAD`), else the sole existing candidate among
-   `main`, `master`, `develop`/`development` (remote-tracking ref first, else the local branch) —
-   failure or ambiguity → ask. Explicit branches in the invocation win. State the chosen target.
+   default branch of the `upstream` remote when one exists (fork workflow), else of `origin` —
+   via `git ls-remote --symref <remote> HEAD`, never the often-absent local
+   `refs/remotes/<remote>/HEAD`; that failing (e.g. offline), the sole existing candidate among
+   `main`, `master`, `develop`/`development` (preferring `upstream`'s remote-tracking ref, then
+   `origin`'s, then the local branch) — still ambiguous or none → ask. Explicit branches in the
+   invocation win. State the chosen target.
 2. `git fetch` the target's remote (local-only target → nothing to fetch; a failed fetch → say
    so and ask rather than diff stale refs), then diff `<target>...HEAD` (merge-base three-dot;
    two-dot only without a common ancestor). Empty diff → probably a wrong target (typical: a
-   fork's default branch already holding the commits) — say so and ask for the true one.
+   fork's default branch already holding the commits) — say so and ask for the true one; it
+   needs no local ref, `git fetch <url> <branch>` works by URL.
 3. Modified tracked files block the run — commit or stash first, no override: the diff covers
-   commits only, so uncommitted work would ship unreviewed under a clean report. Untracked files
-   don't block: they can't ship unless committed. This skill's own artifacts (report,
-   planning-home files) don't count as dirty.
+   commits only, so uncommitted work would ship unreviewed under a clean report. Untracked
+   files don't block, but list them and have the author confirm none belong to the change — a
+   forgotten `git add` ships unreviewed later; any that do belong, the author commits before
+   proceeding. Only the report this skill writes is exempt from both checks.
 
 Done when source branch, target, and reviewed SHA are recorded and the diff is non-empty.
 
@@ -47,7 +51,8 @@ Load and follow [fresh-eyes-review](../fresh-eyes-review/SKILL.md) on the pinned
 inputs all explicit, so it runs without its confirmation step — with:
 
 - an intent statement — the task's ticket or requirements when the planning home holds them, else
-  derived from the branch name and commit subjects;
+  derived from the branch name and commit subjects; derivation yielding noise (`wip` commits,
+  opaque names) → ask the author for a one-liner, proposing a draft;
 - excluded paths: the planning home and the report — author rationale and past dispositions must
   never reach the reviewer. Planning files the changeset itself touches ship in the PR, so they
   are reviewed like any other change; the report stays excluded always;
@@ -58,7 +63,7 @@ inputs all explicit, so it runs without its confirmation step — with:
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it
-  covered every changed file.
+  covered every changed file — naming any it didn't.
 
 Done when the reviewer has returned its findings — possibly none — its provenance, and its
 coverage.
@@ -75,10 +80,9 @@ One finding at a time, recommending a disposition with a one-line why — the au
 Never drop or soften a finding: every one appears in the report with its disposition. When
 anything was fixed, offer one re-review round on the new SHA once the author has committed —
 offered, never forced, no loop; declined or left uncommitted, the report carries a "fixes not
-re-reviewed" caveat. A re-review carries dispositions forward: a re-raised finding matching a
-dismissed one keeps its dismissal, only new findings are walked, and the report lists each
-finding once. Close the walk by reminding the author to run the project's usual checks (build,
-lint, tests) before pushing — this skill never runs them.
+re-reviewed" caveat, and any fix still uncommitted at report time is marked `fixed (uncommitted)`.
+A re-review carries dispositions forward: a re-raised finding matching a dismissed one keeps its
+dismissal, only new findings are walked, and the report lists each finding once.
 
 Done when every finding is dispositioned.
 
@@ -87,23 +91,26 @@ Done when every finding is dispositioned.
 `<slug>.SELF-REVIEW.md` in the task's planning home, per the project's planning-directory
 convention (e.g. `.agents/plans/<slug>/`); reuse the slug of the task's existing artifacts
 (ticket, requirements, plan) — none → derive it from context (branch name, the changes); no
-planning home resolvable → ask where to save it. Re-runs and later rounds update the file in
-place — one file per task, never versioned copies: its destination is a single upload. It is for
-pasting into the PR description or a comment, not for committing, unless the project rules file
-says otherwise — either way committing is the author's move, never the agent's.
+planning home resolvable → default to `.agents/plans/<slug>/`, stating the choice rather than
+asking. Re-runs and later rounds update the file in place — read it first and carry its rounds
+and dispositions forward, under the re-review matching rule — one file per task, never versioned
+copies: its destination is a single upload. It is for pasting into the PR description or a
+comment, not for committing, unless the project rules file says otherwise — either way committing
+is the author's move, never the agent's.
 
 Compact above all: one line per finding, fusing location and concrete failure; the full prose
-stays in the session. Provenance exactly as the environment reports it, `unknown` when it
-doesn't — never guessed or recalled; the reviewer's model, when it differs from the session's,
-appended to the **By** line as `review by <model>`; skill version from this file's frontmatter,
-date = today. Caveats (fixes not re-reviewed, a same-context fallback review, incomplete
-coverage) are visible header lines.
+stays in the session. The **Reviewed** header line always carries the latest round's SHA and
+diffstat; history lives in the round headings. Provenance exactly as the environment reports it,
+`unknown` when it doesn't — never guessed or recalled; the reviewer's model, when it differs from
+the session's, appended to the **By** line as `review by <model>`; skill version from this file's
+frontmatter, date = today. Caveats (fixes not re-reviewed, a same-context fallback review,
+incomplete coverage naming the unreviewed files) are visible header lines.
 
 ```markdown
 # Self-review — my-feature → main
 
 > **Outcome** 3 findings — 2 fixed, 1 dismissed — final round clean
-> **Reviewed** `abc1234` (`my-feature` vs `main`, merge-base diff — 12 files, +340 −120)
+> **Reviewed** `def5678` (`my-feature` vs `main`, merge-base diff — 12 files, +340 −120)
 > **By** <harness>, <model> — self-review v<version>, <date>
 > **Project rules** `.agents/docs/self-review-rules.md` not present
 
@@ -122,8 +129,12 @@ version and date, rules-file status, and every round with its SHA and dispositio
 
 ## Wrap up
 
-Print the report's project-relative path and the instruction to paste its content into the PR
-description or a comment. Done when both are printed.
+Print: the report's project-relative path, with the instruction to paste its content into the PR
+description or a comment; a warning not to commit the report — a later `git add .` drags it into
+the PR — unless the project rules file says otherwise; a reminder to run the project's usual
+checks (build, lint, tests) before pushing — this skill never runs them; and that any commit
+after the review needs a re-run, so the reported SHA matches the pushed head. Done when all four
+are printed.
 
 ## Boundaries
 


### PR DESCRIPTION
# New `/self-review` skill

## What and why

Adds a `self-review` skill: it runs a fresh-context review of your own changeset before you open
the PR, walks you through every finding one by one, and writes a compact report you attach to the
PR.

The driver is maintainer load in open source. Projects like [AzerothCore](https://github.com/azerothcore/azerothcore-wotlk) are getting a lot of sloppy
AI-generated PRs and maintainers can't keep up, so the report doubles as proof the contributor
actually reviewed their work before submitting. The skill itself stays generic, there's nothing
AzerothCore or even OSS specific in it.

## Decisions worth knowing

- The reviewing is delegated to `fresh-eyes-review` rather than reimplemented (see the "Review"
  section, and the new `requires` entry in `openpack.json`). This skill owns pinning the changeset,
  the disposition walk and the report.
- The planning home and the report are excluded from the reviewer's readable paths, so the author's
  own rationale can't leak into the fresh context and defeat the point of it being fresh.
- Uncommitted tracked changes block the run ("Pin the changeset", step 2), because the diff only
  covers commits and uncommitted work would otherwise ship unreviewed under a clean report.
- Projects tune the review through an optional `.agents/docs/self-review-rules.md` instead of
  anything project-specific living in the skill, which keeps it inside the repo's "skills must be
  generic" rule.
- Rounds are capped at 3 to bound cost, and dispositions carry forward between rounds so a
  dismissed finding doesn't get re-argued every time.

## Review guide

`skills/self-review/SKILL.md` is where all the judgment sits. The parts worth reading closely:

- "Pin the changeset". Target detection prefers `upstream` over `origin` for fork workflows, and
  each fallback (no symref, shallow clone, empty diff) has its own exit. These are the paths most
  likely to strand a contributor who isn't comfortable with git.
- "Disposition walk" and "Report". The carry-forward rules across rounds, and whether the report
  format actually stays scannable, since making maintainers' lives easier is the whole point.
- The instructions this skill hands to `fresh-eyes-review` should match what that skill accepts.
  Its step 2 skips the confirmation prompt only when the caller supplies changeset, intent and
  mandate explicitly, which is what happens here.

`README.md` and `openpack.json` are mechanical: catalog entry, graph edge, dependency.

## Known gaps

- Version is 0.1, so it hasn't had a real run yet. Convention here is to bump to 1.0 after one.
- It never runs build, lint or tests, it just prints a reminder at the end. Deliberate, but it does
  mean a clean report says nothing about whether the change compiles.
- The report is self-attested. Harness and model come from whatever the environment reports
  (`unknown` when it doesn't), and nothing stops someone from hand-writing one.
