### PR TITLE
feat(review-code-assistant): verify claims, follow links, still-needed lens

### DIFF
--- a/skills/review-code-assistant/SKILL.md
+++ b/skills/review-code-assistant/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "1.8"
+  version: "1.9"
 ---
 
 # Review code assistant
@@ -55,6 +55,10 @@ When a URL is given, identify the platform from its host and fetch through whate
 tool is available, or no link was given, degrade gracefully to a local-diff-only review, or ask.
 
 - Use the title and description to understand intent.
+- Follow linked issues and PRs: a linked issue's description is part of the intent, and a linked
+  PR may have superseded or already delivered the change.
+- Treat claims in the description and comments as hypotheses, not facts: "fixed in the latest
+  push" or "this breaks X" counts only once the diff or code confirms it.
 - Read existing human comments only lightly, solely to avoid duplicating feedback already raised.
 - Ignore bot and CI comments.
 
@@ -68,6 +72,8 @@ nothing produces no output.
 - **Duplication and bad practices** — relevant repeated logic that should reuse something, and
   general bad practice. Relevant, not "these two lines look vaguely similar".
 - **Intent mismatch** — does the diff actually do what the description claims; anything missing.
+- **Still needed** — the target may have gained the same fix since the branch forked; a change
+  that no longer applies against the current target is itself a finding.
 - **Realistic risk** — security or performance footguns that genuinely apply here, not an audit.
 - **Leftovers** — debug prints, commented-out code, stray TODOs, accidentally committed files.
 

--- a/skills/review-code-assistant/SKILL.md
+++ b/skills/review-code-assistant/SKILL.md
@@ -59,7 +59,8 @@ tool is available, or no link was given, degrade gracefully to a local-diff-only
   PR may have superseded or already delivered the change.
 - Treat claims in the description and comments as hypotheses, not facts: "fixed in the latest
   push" or "this breaks X" counts only once the diff or code confirms it.
-- Read existing human comments only lightly, solely to avoid duplicating feedback already raised.
+- Read existing human comments only lightly: to avoid duplicating feedback already raised, and
+  to catch claims that need verification before you rely on them.
 - Ignore bot and CI comments.
 
 ## Review lenses
@@ -71,7 +72,8 @@ nothing produces no output.
 - **Consistency** — matches the surrounding patterns and naming.
 - **Duplication and bad practices** — relevant repeated logic that should reuse something, and
   general bad practice. Relevant, not "these two lines look vaguely similar".
-- **Intent mismatch** — does the diff actually do what the description claims; anything missing.
+- **Intent mismatch** — does the diff actually do what the title and description claim; anything
+  missing, and a title that oversells or hides a behaviour change.
 - **Still needed** — the target may have gained the same fix since the branch forked; a change
   that no longer applies against the current target is itself a finding.
 - **Realistic risk** — security or performance footguns that genuinely apply here, not an audit.
@@ -129,6 +131,7 @@ Local text only; write no file unless the user later asks to save it.
 
 - Lead with one short sentence recapping what the PR does, to show the change was understood.
 - Then the comment list, or a one-line `Looks good, no comments.`
+- Say plainly what you verified and what you could not (e.g. behaviour only testable at runtime).
 - Each item: a `###` heading holding its sequential finding number and the clickable `path:line`,
   the explanation beneath it, then the optional suggested comment. Put a full-width heavy rule (a
   row of ~40 `━`) above each finding and one more after the last, so the list is bracketed top and

--- a/skills/review-code-assistant/SKILL.md
+++ b/skills/review-code-assistant/SKILL.md
@@ -56,11 +56,11 @@ tool is available, or no link was given, degrade gracefully to a local-diff-only
 
 - Use the title and description to understand intent.
 - Follow linked issues and PRs: a linked issue's description is part of the intent, and a linked
-  PR may have superseded or already delivered the change.
-- Treat claims in the description and comments as hypotheses, not facts: "fixed in the latest
-  push" or "this breaks X" counts only once the diff or code confirms it.
+  PR may have superseded or already fixed it.
+- Treat claims in the description and comments ("fixed in the latest push", "this breaks X") as
+  hypotheses until the diff or code confirms them.
 - Read existing human comments only lightly: to avoid duplicating feedback already raised, and
-  to catch claims that need verification before you rely on them.
+  to spot claims to verify.
 - Ignore bot and CI comments.
 
 ## Review lenses
@@ -75,7 +75,7 @@ nothing produces no output.
 - **Intent mismatch** — does the diff actually do what the title and description claim; anything
   missing, and a title that oversells or hides a behaviour change.
 - **Still needed** — the target may have gained the same fix since the branch forked; a change
-  that no longer applies against the current target is itself a finding.
+  that no longer applies is itself a finding.
 - **Realistic risk** — security or performance footguns that genuinely apply here, not an audit.
 - **Leftovers** — debug prints, commented-out code, stray TODOs, accidentally committed files.
 


### PR DESCRIPTION
While reviewing AzerothCore PRs with this skill I kept adding the same instructions by hand, so here they are as generic skill text:

- Follow linked issues and PRs when enriching from the PR link: the linked issue's description is part of the intent, and a linked PR may have superseded the change under review.
- Treat claims in the description and comments as hypotheses until the diff or code confirms them ("fixed in the latest push", "this breaks X"); the comment-reading bullet is reworded accordingly, since "solely to avoid duplicating feedback" no longer held.
- A new "Still needed" lens: on long-lived PRs the target often gains the same fix after the branch forked, and a change that no longer applies is itself a finding.
- The intent-mismatch lens now also covers the title (overselling, hiding a behaviour change), and the output states what was verified and what could not be.

Version bumped to 1.9.
