### PR TITLE
fix: improve self-review and fresh-eyes-review

### DIFF
--- a/skills/fresh-eyes-review/SKILL.md
+++ b/skills/fresh-eyes-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Fresh-eyes review
@@ -41,14 +41,17 @@ artifacts.
    excluded: any exclusions the invocation supplies, plus, when this session authored the change,
    session-authored files that are not part of it (plans, notes, scratch), since a fresh context
    cannot tell them apart. Its mandate, unless the invocation redirects it (e.g. security only):
-   regressions and correctness, including contradictions with surrounding code, rules, or docs;
-   ambiguities a reader without context would trip on; and, when an intent statement was given,
-   whether the change does what it says. Tough but grounded, aimed at mistakes that matter: every
-   finding names its location and a concrete failure scenario; style nits, speculation, and
-   padding are out of scope, and zero findings is a valid outcome. If the harness cannot isolate
-   a context, fall back to an adversarial pass over the same inputs in the main session. Done
-   when an isolated reviewer has returned its findings, or the fallback pass ran and its result
-   is flagged as same-context (weaker).
+   regressions and correctness, including contradictions with surrounding code, rules, or docs —
+   though matching surrounding code is not correctness: verify any pattern the change extends or
+   mirrors is itself sound, since completing a broken rollout inherits its breakage; ambiguities
+   a reader without context would trip on; and, when an intent statement was given, whether the
+   change does what it says. Tough but grounded, aimed at mistakes that matter: every finding
+   names its location and a concrete failure scenario; style nits, speculation, and padding are
+   out of scope, and zero findings is a valid outcome. Out of scope bounds what is reported,
+   never what is investigated: a pre-existing anomaly in the mechanism the change touches is a
+   reason to audit it. If the harness cannot isolate a context, fall back to an adversarial pass
+   over the same inputs in the main session. Done when an isolated reviewer has returned its
+   findings, or the fallback pass ran and its result is flagged as same-context (weaker).
 4. **Report back.** Relay every finding intact — location and failure scenario included — plus
    whatever else the reviewer was instructed to return; add the session's own assessment when
    useful, but never silently drop or soften a finding. What to do with the findings is the

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.1"
+  version: "0.2"
 ---
 
 # Self-review
@@ -80,8 +80,9 @@ One finding at a time, recommending a disposition with a one-line why — the au
 
 - **fix** — apply it to the working tree now; committing stays the author's move.
 - **dismiss** — record the author's reason, pushing once toward one a maintainer can evaluate
-  ("mirrors the existing pattern in this file", not "disagree"); if the author insists, their
-  words go in verbatim.
+  ("the caller already null-checks", not "disagree"); "mirrors the existing pattern" counts only
+  once that pattern is verified sound — an unchecked one ratifies its bugs; if the author
+  insists, their words go in verbatim.
 
 Never drop or soften a finding: every one appears in the report with its disposition. Anything
 fixed → the author commits (always their move) and a fresh round runs on the new SHA — fixes are
@@ -130,8 +131,8 @@ visible header lines.
 
 1. `src/foo.c:142` — null deref when the timer expires mid-update → **fixed**
 2. `db/updates/xyz.sql:3` — DELETE misses linked_id rows, orphans on re-run → **fixed**
-3. `src/foo.c:97` — guard duplicates the check 4 lines up → **dismissed**: mirrors the existing
-   pattern in this file, refactor out of scope
+3. `src/foo.c:97` — guard duplicates the check 4 lines up → **dismissed**: mirrors the pattern in
+   this file, checked sound at :61 and :88; refactor out of scope
 
 ## Round 2 — `def5678`, clean
 ```


### PR DESCRIPTION
This was part of a test review of a PR that caused regressions in the master tree.
After the test, the agent confirmed that a self-review would've caught the regressions before they surfaced.
They also created these edits as part of a self-improve.