### PR TITLE
feat(install/windows): tell the user when the installers cannot symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Update in one command:
 cd agent-toolkit && git pull && ./install.sh
 ```
 
+On Windows the entries are usually copies rather than symlinks, so updating there needs `--force`
+(see [Windows](./docs/install-skills.md#windows)).
+
 How the symlink install works and the other install methods — hand-picking skills, other agents,
 [skills.sh](https://skills.sh/), the Claude Code plugin marketplace — are covered in
 [docs/install-skills.md](./docs/install-skills.md).

--- a/docs/install-rules.md
+++ b/docs/install-rules.md
@@ -22,8 +22,9 @@ From the repo root:
 
 It mirrors [the skills install](./install-skills.md): the same two symlink layers
 (`~/.agents/rules` → `~/.claude/rules`), converging re-runs, and `--agents-dir`, `--rules-dir`,
-and `--force` options. Rule links left by older `./install.sh` runs stay intact but are updated
-only by this script — run it after `git pull` to keep them in sync.
+and `--force` options, and the same [Windows](./install-skills.md#windows) caveat, where updating
+means re-running this script with `--force`. Rule links left by older `./install.sh` runs stay
+intact but are updated only by this script — run it after `git pull` to keep them in sync.
 
 ## Linking rules by hand
 

--- a/docs/install-skills.md
+++ b/docs/install-skills.md
@@ -16,8 +16,9 @@ The skills become available in all your projects without copying files around, a
 wired to `~/.agents` shares the same set.
 
 Re-running converges: correct links are left alone, links from the old direct layout are
-re-pointed, and broken links owned by this repo are pruned — so `git pull && ./install.sh` always
-brings an existing install up to date.
+re-pointed, and broken links owned by this repo are pruned — so `git pull && ./install.sh` brings
+an existing install up to date, as long as the entries really are symlinks (see
+[Windows](#windows)).
 
 First clone the repo (or your own fork):
 
@@ -52,6 +53,32 @@ ln -s ~/.agents/skills/run-nx-checks ~/.claude/skills/
 Start a new session and run `/context` to confirm everything is loaded. Skills apply at the user
 level (all projects); to scope them to one project, wire that project's directory instead, e.g.
 `./install.sh --skills-dir <project>/.claude/skills`.
+
+## Windows
+
+This section applies to both installers.
+
+Git Bash and MSYS silently copy instead of linking when they cannot create a native symlink, which
+is the default situation. The install still appears to work, but every entry is a snapshot frozen
+at install time, and re-running skips it (a copy is not a link this repo owns), so the installed
+content quietly stays on its original version forever. The installers detect this and warn.
+
+Where that happens, update with `--force`, which replaces the copies:
+
+```sh
+git pull && ./install.sh --force                    # skills
+git pull && ./install-opinionated-rules.sh --force  # rules, if you installed them
+```
+
+Two limits worth knowing. `--force` overwrites whatever holds the name, including an entry you put
+there yourself by hand. And it refreshes content only: an entry deleted from this repo stays
+installed, because pruning recognizes broken symlinks and a copy is not one, so remove those by
+hand.
+
+Real symlinks, which need no `--force`, require both Windows Developer Mode and an MSYS configured
+to create them. That is a machine-wide setup outside this repo's scope, and getting it half right
+(`MSYS=winsymlinks:nativestrict` without the privilege to create symlinks) makes `ln -s` fail
+instead of copying.
 
 ## Other agents
 

--- a/install-opinionated-rules.sh
+++ b/install-opinionated-rules.sh
@@ -84,6 +84,7 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
+check_symlink_support
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed
@@ -91,10 +92,12 @@ resolve_agents_dir
 echo "Agents dir -> ${AGENTS_DIR}/rules"
 mkdir -p "${AGENTS_DIR}/rules"
 prune_dir "${AGENTS_DIR}/rules"
+begin_phase
 for rule in "${REPO_DIR}"/rules/*.md; do
   [ -e "$rule" ] || continue
   link_one "$rule" "${AGENTS_DIR}/rules"
 done
+end_phase
 
 # Phase 2: populate the agent's dir with links to the agent-neutral entries.
 # Skipped entirely when the agent dir IS the agent-neutral dir: linking a dir
@@ -107,15 +110,20 @@ if [ "$(cd "$RULES_DIR" && pwd -P)" = "${AGENTS_DIR}/rules" ]; then
   echo "  ok     (this is the agents dir itself; already populated)"
 else
   prune_dir "$RULES_DIR"
+  begin_phase
   for rule in "${REPO_DIR}"/rules/*.md; do
     [ -e "$rule" ] || continue
     src="${AGENTS_DIR}/rules/$(basename "$rule")"
     if [ ! -e "$src" ]; then
+      count_skip
       echo "  skip   $(basename "$rule") (no usable entry in agents dir)"
       continue
     fi
     link_one "$src" "$RULES_DIR"
   done
+  end_phase
 fi
+
+report_install_health
 
 echo "Done."

--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,7 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
+check_symlink_support
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed
@@ -94,10 +95,12 @@ resolve_agents_dir
 echo "Agents dir -> ${AGENTS_DIR}/skills"
 mkdir -p "${AGENTS_DIR}/skills"
 prune_dir "${AGENTS_DIR}/skills"
+begin_phase
 for skill in "${REPO_DIR}"/skills/*/; do
   [ -d "$skill" ] || continue
   link_one "${skill%/}" "${AGENTS_DIR}/skills"
 done
+end_phase
 
 # Phase 2: populate the agent's dir with links to the agent-neutral entries.
 # Skipped entirely when the agent dir IS the agent-neutral dir: linking a dir
@@ -110,15 +113,18 @@ if [ "$(cd "$SKILLS_DIR" && pwd -P)" = "${AGENTS_DIR}/skills" ]; then
   echo "  ok     (this is the agents dir itself; already populated)"
 else
   prune_dir "$SKILLS_DIR"
+  begin_phase
   for skill in "${REPO_DIR}"/skills/*/; do
     [ -d "$skill" ] || continue
     src="${AGENTS_DIR}/skills/$(basename "${skill%/}")"
     if [ ! -e "$src" ]; then
+      count_skip
       echo "  skip   $(basename "${skill%/}") (no usable entry in agents dir)"
       continue
     fi
     link_one "$src" "$SKILLS_DIR"
   done
+  end_phase
 fi
 
 # Rule links from earlier installs are managed by the opt-in installer; leave
@@ -130,5 +136,7 @@ if [ -d "${AGENTS_DIR}/rules" ]; then
     break
   done
 fi
+
+report_install_health
 
 echo "Done."

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -30,15 +30,16 @@ PHASE_SKIPPED=0
 # failed outright copied nothing, and reporting that as copying would send the
 # user after the wrong problem.
 check_symlink_support() {
-  local probe="${AGENTS_DIR}/.symlink-probe.$$"
-  # Sweep first: cleanup below only knows the current PID, so an interrupted
-  # earlier run would leave its probe behind forever.
-  rm -rf -- "${AGENTS_DIR}"/.symlink-probe.*
-  : > "${probe}.target"
-  if ln -s -- "${probe}.target" "$probe" 2>/dev/null && [ ! -L "$probe" ]; then
+  local probe_dir link
+  # Own dir, so the cleanup below can't touch a concurrent installer's probe or
+  # anything the user keeps here. If mktemp fails, stay quiet rather than guess.
+  probe_dir="$(mktemp -d "${AGENTS_DIR}/.symlink-probe.XXXXXX" 2>/dev/null)" || return 0
+  link="${probe_dir}/link"
+  : > "${probe_dir}/target"
+  if ln -s -- "${probe_dir}/target" "$link" 2>/dev/null && [ ! -L "$link" ]; then
     SYMLINKS_REAL=0
   fi
-  rm -rf -- "$probe" "${probe}.target"
+  rm -rf -- "$probe_dir"
 }
 
 # A symlink is "ours" if it points into this repo clone or the agents dir.
@@ -126,7 +127,8 @@ report_install_health() {
     echo "  Windows). The installed entries are snapshots that do not follow this repo, so" >&2
     echo "  re-run with --force after updating it to refresh them." >&2
   elif [ "$NOTHING_INSTALLED" -eq 1 ]; then
-    echo "Nothing was installed: the names are held by entries this script does not own." >&2
-    echo "  Re-run with --force to replace them (this deletes what is currently there)." >&2
+    echo "The install names are held by entries this script does not own, so the installed" >&2
+    echo "  content will not follow this repo. Re-run with --force to replace those entries" >&2
+    echo "  (this deletes what is currently there)." >&2
   fi
 }

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -15,6 +15,32 @@ resolve_agents_dir() {
   AGENTS_DIR="$(cd "$AGENTS_DIR" && pwd -P)"
 }
 
+SYMLINKS_REAL=1
+NOTHING_INSTALLED=0
+PHASE_DONE=0
+PHASE_SKIPPED=0
+
+# Git Bash/MSYS on Windows falls back to copying when it cannot create a native
+# symlink. The copies are snapshots that never track the repo, and re-running
+# skips them because they are not links we own, so an install silently freezes
+# at whatever it was on its first run. Detect it quietly; report_install_health
+# decides whether it is worth telling the user. On Windows this is a property of
+# the process, not of a directory, so one probe answers for every destination.
+# Only a *successful* ln that yields a non-symlink means copying: an ln that
+# failed outright copied nothing, and reporting that as copying would send the
+# user after the wrong problem.
+check_symlink_support() {
+  local probe="${AGENTS_DIR}/.symlink-probe.$$"
+  # Sweep first: cleanup below only knows the current PID, so an interrupted
+  # earlier run would leave its probe behind forever.
+  rm -rf -- "${AGENTS_DIR}"/.symlink-probe.*
+  : > "${probe}.target"
+  if ln -s -- "${probe}.target" "$probe" 2>/dev/null && [ ! -L "$probe" ]; then
+    SYMLINKS_REAL=0
+  fi
+  rm -rf -- "$probe" "${probe}.target"
+}
+
 # A symlink is "ours" if it points into this repo clone or the agents dir.
 is_ours() {
   local target
@@ -44,6 +70,7 @@ link_one() {
 
   if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$src" ]; then
     echo "  ok     ${name}"
+    PHASE_DONE=$((PHASE_DONE + 1))
     return
   fi
 
@@ -52,16 +79,54 @@ link_one() {
       rm -- "$dest"
       ln -s -- "$src" "$dest"
       echo "  relink ${name}"
+      PHASE_DONE=$((PHASE_DONE + 1))
       return
     fi
     if [ "$FORCE" -eq 1 ]; then
       rm -rf -- "$dest"
     else
       echo "  skip   ${name} (already exists; use --force to overwrite)"
+      count_skip
       return
     fi
   fi
 
   ln -s -- "$src" "$dest"
   echo "  link   ${name}"
+  PHASE_DONE=$((PHASE_DONE + 1))
+}
+
+# An entry the caller gave up on before link_one saw it.
+count_skip() {
+  PHASE_SKIPPED=$((PHASE_SKIPPED + 1))
+}
+
+# Phases are counted separately: a phase that installed nothing is worth
+# reporting even when the other one did work, since the install as a whole is
+# then wired to something this repo did not put there.
+begin_phase() {
+  PHASE_DONE=0
+  PHASE_SKIPPED=0
+}
+
+end_phase() {
+  if [ "$PHASE_SKIPPED" -gt 0 ] && [ "$PHASE_DONE" -eq 0 ]; then
+    NOTHING_INSTALLED=1
+  fi
+  return 0
+}
+
+# Silent unless the run needs something from the user. Two cases qualify: an
+# environment that cannot link, where the install looks fine but will never
+# update itself, and a phase that installed nothing at all, which otherwise
+# reads as a successful no-op. A run that got its work done stays quiet.
+report_install_health() {
+  if [ "$SYMLINKS_REAL" -eq 0 ]; then
+    echo "Warning: this shell copies instead of creating symlinks (typical for Git Bash on" >&2
+    echo "  Windows). The installed entries are snapshots that do not follow this repo, so" >&2
+    echo "  re-run with --force after updating it to refresh them." >&2
+  elif [ "$NOTHING_INSTALLED" -eq 1 ]; then
+    echo "Nothing was installed: the names are held by entries this script does not own." >&2
+    echo "  Re-run with --force to replace them (this deletes what is currently there)." >&2
+  fi
 }


### PR DESCRIPTION
## Problem

Git Bash and MSYS silently copy when they cannot create a native symlink. The install
reports success, but the entries are snapshots, and re-running skips them since a copy is
not a link this repo owns. The content never updates again and nothing says so. An
all-skipped run also reads as a clean no-op.

## Change

Probe for symlink support once per run. `report_install_health` then prints at the end of
the run in two cases only:

- the shell cannot symlink, so entries are copies and updating needs `--force`;
- a phase installed nothing, every name being held by something the script does not own.

Both go to stderr. Only a *successful* `ln` yielding a non-symlink counts as copying, so a
hard `ln` failure keeps its own error instead.

Docs: `docs/install-skills.md` gains a Windows section for both installers, including that
`--force` overwrites hand-made entries and refreshes content without removing entries
deleted from the repo. `README.md` and `docs/install-rules.md` no longer claim
`git pull && ./install.sh` always updates an install.

## No new output on a healthy system

Old vs new across 13 scenarios with working symlinks (fresh, re-run, `--force`, foreign
symlink, real dir, real file, broken owned/foreign symlink, agents dir == skills dir,
project skills dir, stale entry): stdout, stderr and exit code byte-identical except the
two intended cases. Rules installer matches too. `link_one` is unchanged apart from three
counter increments.
