### PR TITLE
fix(review): run convention docs against the submission, not just the diff

### DIFF
--- a/skills/review-code-assistant/SKILL.md
+++ b/skills/review-code-assistant/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "1.9"
+  version: "1.10"
 ---
 
 # Review code assistant
@@ -80,10 +80,10 @@ nothing produces no output.
 - **Leftovers** — debug prints, commented-out code, stray TODOs, accidentally committed files.
 
 Before reviewing, load the project's own convention docs (CLAUDE.md/AGENTS.md and any relevant
-codestyle/contributing docs), then run them as a checklist against every changed file, not as
-background reading. A clear violation is a first-class, citable comment and the skill's edge over a
-human, easiest to miss in new test files (test-structure conventions) and on new class members
-(visibility and naming).
+codestyle/contributing docs), then run them as a checklist, not as background reading, against
+every changed file and the submission itself (title, description, linked issues). A clear
+violation is a first-class, citable comment and the skill's edge over a human, easiest to miss in
+new test files (test-structure conventions) and on new class members (visibility and naming).
 
 ## Grounded, not speculative
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
 ---
 
 # Self-review
@@ -64,8 +64,10 @@ inputs all explicit, so it runs without its confirmation step — with:
   are reviewed like any other change; the report stays excluded always;
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
-  as a checklist against every changed file, not as background reading; and leftovers — debug
-  prints, commented-out code, stray TODOs, accidentally committed files;
+  as a checklist, not as background reading, against every changed file and the submission itself,
+  whose metadata the prompt must carry (commit subjects, and any PR title, description, linked
+  issues); and leftovers — debug prints, commented-out code, stray TODOs, accidentally committed
+  files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it


### PR DESCRIPTION
Both review skills tell the reviewer to run the project's convention docs "as a checklist against
every changed file". Anything those docs say about the submission itself, the title, the
description, linked issues, sits outside that by construction, so it silently never gets checked
and the review still comes back clean.

Ran into it for real on an AzerothCore PR: their `code-review.md` says the title has to follow the
commit message guidelines, the title had the wrong scope, and the review reported clean anyway.

self-review needed a second half. The reviewer prompt only carried a commit SHA, so even with a
wider mandate there was no title or description for it to look at.

self-review 0.3 -> 0.4, review-code-assistant 1.9 -> 1.10.

Note: #24 also bumps self-review to 0.4. The hunks are in different sections and don't overlap, so
whichever lands second just renumbers to 0.5.
