### PR TITLE
feat: maintainer-review, the maintainer's side of the merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Review helpers that check the codebase while assisting with code or ticket revie
   turning the accepted changes into a requirements doc.
 - **[review-code-assistant](./skills/review-code-assistant/SKILL.md)** — assist you in reviewing a
   PR or branch.
+- **[maintainer-review](./skills/maintainer-review/SKILL.md)** — review someone else's PR as the
+  maintainer deciding whether it merges: every prior comment walked, every claim verified, then
+  comment, approve or fix the contributor's branch on your go-ahead.
 - **[use-conversational-language](./skills/use-conversational-language/SKILL.md)** — the voice for
   text that should read as if a person typed it, used by the review skills for comments and
   replies and by rules for user-facing texts and code comments.
@@ -172,6 +175,9 @@ flowchart TD
   refine_pr --> express["use-conversational-language"]
   review_code["review-code-assistant"] --> express
   self_review["self-review"] --> fresh_eyes["fresh-eyes-review"]
+  maintainer_review["maintainer-review"] --> review_code
+  maintainer_review --> fresh_eyes
+  maintainer_review --> express
   realistic_rule["write-realistic-texts rule"] --> express
   nonsense_rule["no-nonsense-comments rule"] --> express
   review_ticket["review-ticket"] --> fetch_ticket

--- a/openpack.json
+++ b/openpack.json
@@ -45,6 +45,13 @@
         "review-code-assistant": {
           "requires": ["skills/use-conversational-language"]
         },
+        "maintainer-review": {
+          "requires": [
+            "skills/review-code-assistant",
+            "skills/fresh-eyes-review",
+            "skills/use-conversational-language"
+          ]
+        },
         "check-ticket-implementation": {
           "requires": ["skills/fetch-ticket"]
         },

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -20,9 +20,9 @@ first.
 
 Take a PR reference on any forge and pull, through whatever tooling is connected, **all** of it
 before judging: metadata (title, description, author, base and head refs, draft state, labels,
-mergeability), the diff, and every comment stream — conversation comments, review verdicts with
-their bodies, and inline threads with their replies. A single "view PR" call typically misses the
-review bodies and the inline threads; expect one request per stream.
+mergeability, required-check results), the diff, and every comment stream — conversation comments,
+review verdicts with their bodies, and inline threads with their replies. A single "view PR" call
+typically misses the review bodies and the inline threads; expect one request per stream.
 
 Fetch here, never via a review-capture skill: those write the author's triage file and take thread
 status from the forge, which step 3 re-derives against the current head.
@@ -30,12 +30,12 @@ status from the forge, which step 3 re-derives against the current head.
 Fetch, then diff the merge base — `<base>...<head>`, three-dot — so the target's own commits don't
 read as the author's. A fork's head has no local ref; fetch the forge's PR ref for it.
 
-Done when the head SHA, the base, the diff and all comment streams are in hand.
+Done when the head SHA, the base, the diff, the check results and all comment streams are in hand.
 
 ## 2. Follow every reference
 
-Extract every issue and PR reference, commit sha, external link and domain identifier (a ticket key,
-a game or product entity id) from the title, the description and **every** comment, then open each,
+Extract every issue and PR reference, commit sha, external link and domain identifier (a ticket key
+or product entity id) from the title, the description and **every** comment, then open each,
 including its own comments. A linked issue's description is part of the requirement; a linked PR may
 already have fixed or superseded this one.
 
@@ -60,7 +60,8 @@ loaded next.
 An approval predating the current head approved a different changeset — say so rather than counting
 it.
 
-Done when every item carries answered, still open, or no longer applies, each with its evidence.
+Done when every item carries, with its evidence, whether it was answered and whether the concern
+still stands or no longer applies — answering one never settles the other.
 
 ## 4. Read the diff
 
@@ -95,19 +96,22 @@ Done when every finding and every walked comment has a stated position.
 ## Acting on the PR
 
 Nothing is posted, approved, labelled, merged or pushed without a **separate** go-ahead naming that
-action. Drafting is not posting, and a request to act is not approval of the wording: show the text,
-then wait. Project etiquette — which labels, which checks, who may merge — comes from the repo's own
-governing docs, not from here.
+action, and re-read the head SHA then: moved since the review, the verdict covers a changeset nobody
+reviewed, so say so rather than act. Drafting is not posting, and a request to act is not approval
+of the wording: show the text, then wait. Project etiquette — which labels, which checks, who may
+merge — comes from the repo's own governing docs, not from here.
 
 - **Comments** — the concern, the location, the suggested change, nothing else. No preamble, no
   recap of the PR, no praise padding. Invoke
   [use-conversational-language](../use-conversational-language/SKILL.md) for the wording.
 - **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
-- **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees. Add
-  their fork as a remote, fetch, check out the branch, bring it current with a **merge** of the
-  target, commit new commits, push fast-forward only. Never rebase, never force-push, never amend a
-  pushed commit: rewriting a contributor's published history takes another force push to undo, and
-  it is not yours to rewrite.
+- **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees; the
+  go-ahead reaches that branch's push and no further. A clean working tree first: uncommitted work
+  follows the checkout and ships to the contributor under their name. Then add the head's remote
+  when it is a fork (a same-repo head needs none), fetch, check out the branch, bring it current
+  with a **merge** of the target, commit the fix's files by path, push fast-forward only. Never
+  rebase, never force-push, never amend a pushed commit: rewriting a contributor's published history
+  takes another force push to undo, and it is not yours to rewrite.
 
 ## Boundaries
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -49,8 +49,9 @@ Done when every reference has been opened or recorded as unreachable.
 
 Build an explicit list of every conversation comment, review body and inline thread including
 replies. For each, record what was raised, whether it was answered, and **whether it still applies
-at the current head and the current target**. A thread gone stale because the target moved counts as
-answered — by the commit and file that did it.
+at the current head and the current target**. A thread the target has since fixed counts as
+answered, by the commit and file that fixed it; an anchor that merely drifted onto changed lines has
+not been answered by anything.
 
 Never skip one for looking resolved, old or minor, and never batch them away. Bot reviewers count:
 their findings are often the only ones on record, and an author's "no, addressed above" is a claim
@@ -67,22 +68,24 @@ still stands or no longer applies — answering one never settles the other.
 
 Load and follow [review-code-assistant](../review-code-assistant/SKILL.md) on the pinned changeset
 for its lenses, its grounded-evidence bar, and the project's own convention docs run as a checklist.
-Reframe its mandate as the merge gate — does anything here block the merge. Its comment handling and
-its read-only boundary are superseded by this skill.
+Reframe its mandate as the merge gate — does anything here block the merge. Its comment handling,
+its branch-freshness rule and its read-only boundary are superseded by this skill: the changeset
+stays the step-1 head SHA, so the diff pass and the comment walk judge the same code.
 
 Done when the diff pass has returned its findings, possibly none.
 
 ## 5. Fresh eyes over the findings
 
-With at least one finding, load [fresh-eyes-review](../fresh-eyes-review/SKILL.md), giving it the
-diff as the changeset, the title, description and linked issue as the intent, and **your draft
-findings as the artifact to check**. Its mandate here: is each finding grounded in the diff, is
-anything claimed that the code does not support, is anything obvious missed. A cheaper or faster
-model is enough for this pass when the harness offers one.
+Load [fresh-eyes-review](../fresh-eyes-review/SKILL.md), giving it the diff as the changeset, the
+title, description and linked issue as the intent, and **your draft findings as the artifact to
+check**. A clean verdict is an artifact too, and the one most worth checking. Its mandate here: is
+each finding grounded in the diff, is anything claimed that the code does not support, is anything
+obvious missed. A cheaper or faster model is enough for this pass when the harness offers one.
 
 Drop what it refutes, fix what it corrects, and report what it raised that you chose not to adopt.
 
-Done when every draft finding was kept, dropped, or knowingly kept against the reviewer's objection.
+Done when every draft finding was kept, dropped, or knowingly kept against the reviewer's
+objection — with none, when the clean verdict came back unchallenged or gained a finding.
 
 ## 6. Report
 
@@ -105,14 +108,20 @@ merge — comes from the repo's own governing docs, not from here.
   recap of the PR, no praise padding. Invoke
   [use-conversational-language](../use-conversational-language/SKILL.md) for the wording.
 - **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
-- **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees; the
-  go-ahead reaches that branch's push and no further. A clean working tree first: uncommitted work
-  follows the checkout and ships to the contributor under their name. Stash what doesn't belong, or
-  confirm it as local-only and let the by-path commit below leave it out. Then add the head's remote
-  when it is a fork (a same-repo head needs none), fetch, check out the branch, bring it current
-  with a **merge** of the target, commit the fix's files by path, push fast-forward only. Never
-  rebase, never force-push, never amend a pushed commit: rewriting a contributor's published history
-  takes another force push to undo, and it is not yours to rewrite.
+- **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees. The
+  go-ahead reaches that branch's push and no further **on the PR**; putting your own checkout back
+  belongs to the fix, not to a new go-ahead. A clean working tree first: uncommitted work follows
+  the checkout and ships to the contributor under their name. Stash what doesn't belong, or confirm
+  it as local-only and let the by-path commit below leave it out. Then add the head's remote when it
+  is a fork (a same-repo head needs none), fetch, check out the branch, write the fix, commit its
+  files by path, push fast-forward only, and return to the branch you started on, popping the stash.
+  Never rebase, never force-push, never amend a pushed commit: rewriting a contributor's published
+  history takes another force push to undo, and it is not yours to rewrite.
+
+  Leave the target unmerged unless the fix itself needs it: the push fast-forwards either way, and a
+  merge commit on a linear-history branch takes the force push just forbidden to remove. Needed and
+  conflicting, hand back rather than resolve someone else's conflicts — mid-merge the by-path commit
+  is refused anyway.
 
 ## Boundaries
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: maintainer-review
+description: Review someone else's pull request as the maintainer deciding whether it merges — every prior comment walked, every claim verified, and nothing posted without your go-ahead.
+disable-model-invocation: true
+type: flow
+license: MIT
+metadata:
+  version: "0.1"
+---
+
+# Maintainer review
+
+You are the merge gate, not the author's assistant: the question is whether this ships, and the
+contributor will argue back. Review in **this** session — it is already fresh context, and only
+findings you verified yourself are ones you can defend. Delegating the pass to a subagent costs you
+that ground and buys nothing.
+
+## 1. Gather
+
+Take a PR reference on any forge and pull, through whatever tooling is connected, **all** of it
+before judging: metadata (title, description, author, base and head refs, draft state, labels,
+mergeability), the diff, and every comment stream — conversation comments, review verdicts with
+their bodies, and inline threads with their replies. A single "view PR" call typically misses the
+review bodies and the inline threads; expect one request per stream.
+
+Fetch, then diff the merge base — `<base>...<head>`, three-dot — so the target's own commits don't
+read as the author's. A fork's head has no local ref; fetch the forge's PR ref for it.
+
+Done when the head SHA, the base, the diff and all comment streams are in hand.
+
+## 2. Follow every reference
+
+Extract every issue and PR reference, commit sha, external link and domain identifier (a ticket key,
+a game or product entity id) from the title, the description and **every** comment, then open each,
+including its own comments. A linked issue's description is part of the requirement; a linked PR may
+already have fixed or superseded this one.
+
+**Never take a claim as fact**, the author's no more than a reviewer's. "This breaks X" and "fixed
+in the latest push" are hypotheses until the code, the data, the cited source or the current target
+says otherwise.
+
+Done when every reference has been opened or recorded as unreachable.
+
+## 3. Walk every comment
+
+Build an explicit list of every conversation comment, review body and inline thread including
+replies. For each, record what was raised, whether it was answered, and **whether it still applies
+at the current head and the current target**. A thread gone stale because the target moved counts as
+answered — by the commit and file that did it.
+
+Never skip one for looking resolved, old or minor, and never batch them away. Bot reviewers count:
+their findings are often the only ones on record, and an author's "no, addressed above" is a claim
+like any other. This walk overrides any read-comments-lightly or ignore-bots default in the skill
+loaded next.
+
+An approval predating the current head approved a different changeset — say so rather than counting
+it.
+
+Done when every item carries answered, still open, or no longer applies, each with its evidence.
+
+## 4. Read the diff
+
+Load and follow [review-code-assistant](../review-code-assistant/SKILL.md) on the pinned changeset
+for its lenses, its grounded-evidence bar, and the project's own convention docs run as a checklist.
+Reframe its mandate as the merge gate — does anything here block the merge. Its comment handling and
+its read-only boundary are superseded by this skill.
+
+Done when the diff pass has returned its findings, possibly none.
+
+## 5. Fresh eyes over the findings
+
+With at least one finding, load [fresh-eyes-review](../fresh-eyes-review/SKILL.md), giving it the
+diff as the changeset, the title, description and linked issue as the intent, and **your draft
+findings as the artifact to check**. Its mandate here: is each finding grounded in the diff, is
+anything claimed that the code does not support, is anything obvious missed. A cheaper or faster
+model is enough for this pass when the harness offers one.
+
+Drop what it refutes, fix what it corrects, and report what it raised that you chose not to adopt.
+
+Done when every draft finding was kept, dropped, or knowingly kept against the reviewer's objection.
+
+## 6. Report
+
+In chat, no file. Lead with the verdict — does it block the merge — then the findings with
+`path:line` evidence, then the comment walk. Close with what you could **not** verify and who has
+to: a review that never ran the code says so, and names what the author should test, including the
+side effects a fix for X reaches in Y.
+
+Done when every finding and every walked comment has a stated position.
+
+## Acting on the PR
+
+Nothing is posted, approved, labelled, merged or pushed without a **separate** go-ahead naming that
+action. Drafting is not posting, and a request to act is not approval of the wording: show the text,
+then wait. Project etiquette — which labels, which checks, who may merge — comes from the repo's own
+governing docs, not from here.
+
+- **Comments** — the concern, the location, the suggested change, nothing else. No preamble, no
+  recap of the PR, no praise padding. Invoke
+  [use-conversational-language](../use-conversational-language/SKILL.md) for the wording.
+- **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
+- **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees. Add
+  their fork as a remote, fetch, check out the branch, bring it current with a **merge** of the
+  target, commit new commits, push fast-forward only. Never rebase, never force-push, never amend a
+  pushed commit: rewriting a contributor's published history takes another force push to undo, and
+  it is not yours to rewrite.
+
+## Boundaries
+
+Read-only git plus `git fetch`, and no writes to the working tree — until a fix is explicitly
+authorised, the sole exception. Output is chat text; write a file only if asked.

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -24,6 +24,9 @@ mergeability), the diff, and every comment stream — conversation comments, rev
 their bodies, and inline threads with their replies. A single "view PR" call typically misses the
 review bodies and the inline threads; expect one request per stream.
 
+Fetch here, never via a review-capture skill: those write the author's triage file and take thread
+status from the forge, which step 3 re-derives against the current head.
+
 Fetch, then diff the merge base — `<base>...<head>`, three-dot — so the target's own commits don't
 read as the author's. A fork's head has no local ref; fetch the forge's PR ref for it.
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -107,7 +107,8 @@ merge — comes from the repo's own governing docs, not from here.
 - **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
 - **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees; the
   go-ahead reaches that branch's push and no further. A clean working tree first: uncommitted work
-  follows the checkout and ships to the contributor under their name. Then add the head's remote
+  follows the checkout and ships to the contributor under their name. Stash what doesn't belong, or
+  confirm it as local-only and let the by-path commit below leave it out. Then add the head's remote
   when it is a fork (a same-repo head needs none), fetch, check out the branch, bring it current
   with a **merge** of the target, commit the fix's files by path, push fast-forward only. Never
   rebase, never force-push, never amend a pushed commit: rewriting a contributor's published history

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -11,9 +11,10 @@ metadata:
 # Maintainer review
 
 You are the merge gate, not the author's assistant: the question is whether this ships, and the
-contributor will argue back. Review in **this** session — it is already fresh context, and only
-findings you verified yourself are ones you can defend. Delegating the pass to a subagent costs you
-that ground and buys nothing.
+contributor will argue back. Review in **this** session, not a subagent. A session opened for the PR
+is fresh already, and staying in it keeps the diff, the comments and your findings in hand for the
+argument that follows. Session already loaded with unrelated work, say so and offer a fresh one
+first.
 
 ## 1. Gather
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.4"
+  version: "0.5"
 ---
 
 # Self-review

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
 ---
 
 # Self-review
@@ -15,6 +15,9 @@ conventions respected — and prove it was scrutinized: a fresh-context reviewer
 would block the merge, the author answers every finding, and a compact report — scannable by a
 maintainer in seconds — records the outcome. The report is the review record only; the change's
 what/why belongs to the PR description (e.g. via /handover), never here.
+
+Only for a changeset you authored. The fresh-context reviewer exists to escape authoring
+blindness, so someone else's PR has nothing to escape and belongs to `maintainer-review`.
 
 ## Pin the changeset
 


### PR DESCRIPTION
## What and why

New `maintainer-review` skill, the partner to `self-review` from the other side of the merge. `self-review` is the contributor checking their own change before they push, `maintainer-review` is the maintainer going through a PR to decide whether it merges. `self-review` also gets a scope guard so it points at the new skill instead of reviewing someone else's PR.

## Decisions worth knowing

The review runs in the current session, where `self-review` delegates it to a fresh-context subagent. `self-review` needs that because a contributor can fire it in the middle of a big session, so the subagent is what guarantees a clean read. A maintainer opens a session to look at a PR, so it's fresh context already, and staying in it keeps the diff, the comment history and the findings all there to discuss with the contributor afterwards. See the header of `skills/maintainer-review/SKILL.md`.

That premise breaks if someone invokes it mid-session with unrelated work loaded, so the skill says so and offers a fresh session. It offers, rather than refusing, because sometimes the loaded context is the point, like when you just reviewed the PR this one builds on.

It composes rather than reimplements: `review-code-assistant` does the diff pass (section 4), `fresh-eyes-review` checks the draft findings before they're stated (section 5).

It deliberately doesn't compose `fetch-pr-review`, which looks like the obvious fit for the comment gathering. That skill reads each thread's status off the forge's resolved flag, and section 3 exists to re-derive exactly that against the current head, so composing it would import the rule the skill is there to contradict. Step 1 says so outright, because `fetch-pr-review` is model-invocable and would otherwise fire on the PR url by itself.

The comment walk in section 3 explicitly overrides read-comments-lightly and ignore-bots defaults in whatever skill loads next, because bot findings are often the only ones on record.

Fixes go on the contributor's own branch, pushed fast-forward only, with no rebase and no force push: undoing a rewrite of someone's published history takes another force push, and it isn't ours to rewrite.

The target is left unmerged unless the fix itself needs it, which reads backwards until you notice the push fast-forwards either way. Merging it in buys nothing, and on a linear-history branch it leaves a merge commit that only the force push we just forbade could remove.

## Review guide

`skills/maintainer-review/SKILL.md` is the change. Worth the judgment: section 3 (the comment walk, including the override above), section 5 (fresh eyes over your own draft findings, which is a bit unusual), and "Acting on the PR", which is where the damage lands if the boundaries are wrong.

`skills/self-review/SKILL.md` adds three lines of scope guard and a version bump.

`README.md` and `openpack.json` are mechanical: catalog entry, dependency graph edges, and the `requires` list.

## Known gaps

It's had one successful run against a real PR, but it ships at 0.1 rather than 1.0, so it keeps its trial status for a while longer.

`self-review`'s scope guard is a statement, not a check. Nothing tells the agent how to spot that a changeset isn't yours, so running `/self-review` on someone else's branch still goes through the normal flow instead of handing off. Left as is on purpose, since the pointer is what makes the new skill discoverable and the slip is easy to catch once the review starts calling you the author.

Step 1 says to pull everything "through whatever tooling is connected" without naming a forge client, so how well it works depends on what the reviewer has hooked up.
