### PR TITLE
fix(install): link the skills through junctions on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Update in one command:
 cd agent-toolkit && git pull && ./install.sh
 ```
 
-On Windows the skills link through junctions, so the update command above works as-is; the rules
-are copied instead and need `--force` (see [Windows](./docs/install-skills.md#windows)).
+On Windows the skills link through junctions, so the update command above works as-is, though an
+install predating them needs one `./install.sh --force` to convert. The rules are copied instead
+and need `--force` every time (see [Windows](./docs/install-skills.md#windows)).
 
 How the symlink install works and the other install methods — hand-picking skills, other agents,
 [skills.sh](https://skills.sh/), the Claude Code plugin marketplace — are covered in

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Update in one command:
 cd agent-toolkit && git pull && ./install.sh
 ```
 
-On Windows the entries are usually copies rather than symlinks, so updating there needs `--force`
-(see [Windows](./docs/install-skills.md#windows)).
+On Windows the skills link through junctions, so the update command above works as-is; the rules
+are copied instead and need `--force` (see [Windows](./docs/install-skills.md#windows)).
 
 How the symlink install works and the other install methods — hand-picking skills, other agents,
 [skills.sh](https://skills.sh/), the Claude Code plugin marketplace — are covered in

--- a/docs/install-rules.md
+++ b/docs/install-rules.md
@@ -22,8 +22,9 @@ From the repo root:
 
 It mirrors [the skills install](./install-skills.md): the same two symlink layers
 (`~/.agents/rules` → `~/.claude/rules`), converging re-runs, and `--agents-dir`, `--rules-dir`,
-and `--force` options, and the same [Windows](./install-skills.md#windows) caveat, where updating
-means re-running this script with `--force`. Rule links left by older `./install.sh` runs stay
+and `--force` options. On [Windows](./install-skills.md#windows) the rules do not get the junction
+fallback the skills do, since each rule is a single file, so updating means re-running this script
+with `--force`. Rule links left by older `./install.sh` runs stay
 intact but are updated only by this script — run it after `git pull` to keep them in sync.
 
 ## Linking rules by hand

--- a/docs/install-rules.md
+++ b/docs/install-rules.md
@@ -24,8 +24,8 @@ It mirrors [the skills install](./install-skills.md): the same two symlink layer
 (`~/.agents/rules` → `~/.claude/rules`), converging re-runs, and `--agents-dir`, `--rules-dir`,
 and `--force` options. On [Windows](./install-skills.md#windows) the rules do not get the junction
 fallback the skills do, since each rule is a single file, so updating means re-running this script
-with `--force`. Rule links left by older `./install.sh` runs stay
-intact but are updated only by this script — run it after `git pull` to keep them in sync.
+with `--force`. Rule links left by older `./install.sh` runs stay intact but are updated only by
+this script — run it after `git pull` to keep them in sync.
 
 ## Linking rules by hand
 

--- a/docs/install-skills.md
+++ b/docs/install-skills.md
@@ -56,18 +56,23 @@ level (all projects); to scope them to one project, wire that project's director
 
 ## Windows
 
-This section applies to both installers.
-
 Git Bash and MSYS silently copy instead of linking when they cannot create a native symlink, which
-is the default situation. The install still appears to work, but every entry is a snapshot frozen
-at install time, and re-running skips it (a copy is not a link this repo owns), so the installed
-content quietly stays on its original version forever. The installers detect this and warn.
+takes either Windows Developer Mode or an elevated shell and so is not the default situation. A
+copy still looks like a working install, but it is a snapshot frozen at install time that
+re-running skips (a copy is not a link this repo owns), so the installed content quietly stays on
+its original version forever.
 
-Where that happens, update with `--force`, which replaces the copies:
+The skills escape this: each one is a directory, and `install.sh` falls back to a
+[directory junction](https://learn.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions),
+which needs no privilege and which MSYS reads back as a symlink. A plain `./install.sh` therefore
+gives you links that follow the repo, and `git pull && ./install.sh` keeps them current.
+
+The rules are single `.md` files, which junctions cannot cover, so
+`install-opinionated-rules.sh` still copies them unless you have Developer Mode or an elevated
+shell. Update those with `--force`, which replaces the copies:
 
 ```sh
-git pull && ./install.sh --force                    # skills
-git pull && ./install-opinionated-rules.sh --force  # rules, if you installed them
+git pull && ./install-opinionated-rules.sh --force
 ```
 
 Two limits worth knowing. `--force` overwrites whatever holds the name, including an entry you put
@@ -75,10 +80,9 @@ there yourself by hand. And it refreshes content only: an entry deleted from thi
 installed, because pruning recognizes broken symlinks and a copy is not one, so remove those by
 hand.
 
-Real symlinks, which need no `--force`, require both Windows Developer Mode and an MSYS configured
-to create them. That is a machine-wide setup outside this repo's scope, and getting it half right
-(`MSYS=winsymlinks:nativestrict` without the privilege to create symlinks) makes `ln -s` fail
-instead of copying.
+Each installer probes what its own entries can do and warns only when they really are copies.
+Junctions are a local-NTFS feature, so installing onto a network or non-NTFS drive falls back to
+copying too.
 
 ## Other agents
 

--- a/docs/install-skills.md
+++ b/docs/install-skills.md
@@ -67,22 +67,31 @@ The skills escape this: each one is a directory, and `install.sh` falls back to 
 which needs no privilege and which MSYS reads back as a symlink. A plain `./install.sh` therefore
 gives you links that follow the repo, and `git pull && ./install.sh` keeps them current.
 
+If you installed the skills before junctions existed, your entries are still copies, and a plain
+re-run skips them because a copy is not a link this repo owns. Convert them once with `--force`,
+after which the plain command is enough:
+
+```sh
+git pull && ./install.sh --force
+```
+
 The rules are single `.md` files, which junctions cannot cover, so
 `install-opinionated-rules.sh` still copies them unless you have Developer Mode or an elevated
-shell. Update those with `--force`, which replaces the copies:
+shell. They need that `--force` on every update, not just once:
 
 ```sh
 git pull && ./install-opinionated-rules.sh --force
 ```
 
-Two limits worth knowing. `--force` overwrites whatever holds the name, including an entry you put
-there yourself by hand. And it refreshes content only: an entry deleted from this repo stays
-installed, because pruning recognizes broken symlinks and a copy is not one, so remove those by
-hand.
+Two limits worth knowing about `--force`. It overwrites whatever holds the name, including an entry
+you put there yourself by hand. And it refreshes content only, so where entries are copies, one
+deleted from this repo stays installed: pruning recognizes broken symlinks, and a copy is not one.
+Junction-linked skills are pruned normally.
 
-Each installer probes what its own entries can do and warns only when they really are copies.
-Junctions are a local-NTFS feature, so installing onto a network or non-NTFS drive falls back to
-copying too.
+Each installer checks the entries it created and warns only when they really are copies. Junctions
+are a local-NTFS feature, so a destination on a network or non-NTFS drive falls back to copying
+even where the rest of the install links, which is worth knowing if you point `--skills-dir` at
+another volume.
 
 ## Other agents
 

--- a/install-opinionated-rules.sh
+++ b/install-opinionated-rules.sh
@@ -84,7 +84,7 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
-check_symlink_support
+check_symlink_support file
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed

--- a/install-opinionated-rules.sh
+++ b/install-opinionated-rules.sh
@@ -83,8 +83,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-resolve_agents_dir
-check_symlink_support file
+resolve_agents_dir file
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed

--- a/install-opinionated-rules.sh
+++ b/install-opinionated-rules.sh
@@ -83,7 +83,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-resolve_agents_dir file
+resolve_agents_dir
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,6 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
-check_symlink_support dir
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed

--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
-check_symlink_support
+check_symlink_support dir
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -16,6 +16,7 @@ resolve_agents_dir() {
 }
 
 SYMLINKS_REAL=1
+COPIED_KIND=dir
 NOTHING_INSTALLED=0
 PHASE_DONE=0
 PHASE_SKIPPED=0
@@ -46,30 +47,22 @@ make_link() {
   ln -s -- "$src" "$dest"
 }
 
-# Whether make_link really links here, probed with the kind of source the caller
-# installs ($1: dir or file) — junctions cover directories but not files, so the
-# answer differs per installer. The copies are snapshots that never track the
-# repo, and re-running skips them because they are not links we own, so an
-# install silently freezes at whatever it was on its first run. Detect it
-# quietly; report_install_health decides whether to tell the user. Only a
-# *successful* link attempt that yields a non-symlink means copying: one that
-# failed outright copied nothing, and reporting that as copying would send the
-# user after the wrong problem.
-check_symlink_support() {
-  local kind="$1" probe_dir link
-  # Own dir, so the cleanup below can't touch a concurrent installer's probe or
-  # anything the user keeps here. If mktemp fails, stay quiet rather than guess.
-  probe_dir="$(mktemp -d "${AGENTS_DIR}/.symlink-probe.XXXXXX" 2>/dev/null)" || return 0
-  link="${probe_dir}/link"
-  if [ "$kind" = dir ]; then
-    mkdir "${probe_dir}/target"
+# Record whether the entry make_link just created is a real link. Copies are
+# snapshots that never track the repo, and re-running skips them because they
+# are not links we own, so an install silently freezes at whatever it was on its
+# first run. Judged from the finished entry rather than an up-front probe:
+# junctions are a per-volume feature and the two destinations an installer
+# writes to can sit on different ones. report_install_health decides whether
+# what we saw is worth telling the user.
+note_link_kind() {
+  local dest="$1"
+  [ -L "$dest" ] && return 0
+  SYMLINKS_REAL=0
+  if [ -d "$dest" ]; then
+    COPIED_KIND=dir
   else
-    : > "${probe_dir}/target"
+    COPIED_KIND=file
   fi
-  if make_link "${probe_dir}/target" "$link" 2>/dev/null && [ ! -L "$link" ]; then
-    SYMLINKS_REAL=0
-  fi
-  rm -rf -- "$probe_dir"
 }
 
 # A symlink is "ours" if it points into this repo clone or the agents dir.
@@ -109,6 +102,7 @@ link_one() {
     if [ -L "$dest" ] && is_ours "$dest"; then
       rm -- "$dest"
       make_link "$src" "$dest"
+      note_link_kind "$dest"
       echo "  relink ${name}"
       PHASE_DONE=$((PHASE_DONE + 1))
       return
@@ -123,6 +117,7 @@ link_one() {
   fi
 
   make_link "$src" "$dest"
+  note_link_kind "$dest"
   echo "  link   ${name}"
   PHASE_DONE=$((PHASE_DONE + 1))
 }
@@ -155,9 +150,17 @@ report_install_health() {
   if [ "$SYMLINKS_REAL" -eq 0 ]; then
     echo "Warning: this environment copies instead of linking, so the installed entries are" >&2
     echo "  snapshots that do not follow this repo; re-run with --force after updating it to" >&2
-    echo "  refresh them. On Windows, links to single files (the rules) need Developer Mode or" >&2
-    echo "  an elevated shell, while links to directories (the skills) fall back to junctions" >&2
-    echo "  and need neither." >&2
+    echo "  refresh them." >&2
+    # Naming the cause the caller's own entries hit: telling someone whose
+    # junctions just failed that junctions cover them sends them after the
+    # wrong problem.
+    if [ "$COPIED_KIND" = file ]; then
+      echo "  On Windows, links to single files like these need Developer Mode or an elevated" >&2
+      echo "  shell; junctions, which need neither, cover only directories." >&2
+    else
+      echo "  On Windows these normally fall back to junctions, which need a local NTFS volume," >&2
+      echo "  so a network or non-NTFS destination is the usual cause." >&2
+    fi
   elif [ "$NOTHING_INSTALLED" -eq 1 ]; then
     echo "The install names are held by entries this script does not own, so the installed" >&2
     echo "  content will not follow this repo. Re-run with --force to replace those entries" >&2

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -20,23 +20,53 @@ NOTHING_INSTALLED=0
 PHASE_DONE=0
 PHASE_SKIPPED=0
 
-# Git Bash/MSYS on Windows falls back to copying when it cannot create a native
-# symlink. The copies are snapshots that never track the repo, and re-running
-# skips them because they are not links we own, so an install silently freezes
-# at whatever it was on its first run. Detect it quietly; report_install_health
-# decides whether it is worth telling the user. On Windows this is a property of
-# the process, not of a directory, so one probe answers for every destination.
-# Only a *successful* ln that yields a non-symlink means copying: an ln that
+WINDOWS=0
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) WINDOWS=1 ;;
+esac
+
+# Link $1 to $2, the best way this environment allows.
+#
+# Git Bash/MSYS silently copies instead of linking unless the process may create
+# native symlinks, which takes Developer Mode or elevation; nativestrict turns
+# that silent copy into an error we can fall back from. A directory junction is
+# the fallback: it needs no privilege, and MSYS reads one back as a symlink, so
+# readlink, -L and rm behave as the rest of this file assumes. Junctions cover
+# directories on a local NTFS volume only, hence the plain ln -s last resort,
+# which copies.
+make_link() {
+  local src="$1" dest="$2"
+  if [ "$WINDOWS" -eq 1 ]; then
+    MSYS=winsymlinks:nativestrict ln -s -- "$src" "$dest" 2>/dev/null && return 0
+    if [ -d "$src" ] && command -v cygpath >/dev/null 2>&1; then
+      MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*' \
+        cmd /c mklink /J "$(cygpath -w "$dest")" "$(cygpath -w "$src")" >/dev/null 2>&1 && return 0
+    fi
+  fi
+  ln -s -- "$src" "$dest"
+}
+
+# Whether make_link really links here, probed with the kind of source the caller
+# installs ($1: dir or file) — junctions cover directories but not files, so the
+# answer differs per installer. The copies are snapshots that never track the
+# repo, and re-running skips them because they are not links we own, so an
+# install silently freezes at whatever it was on its first run. Detect it
+# quietly; report_install_health decides whether to tell the user. Only a
+# *successful* link attempt that yields a non-symlink means copying: one that
 # failed outright copied nothing, and reporting that as copying would send the
 # user after the wrong problem.
 check_symlink_support() {
-  local probe_dir link
+  local kind="$1" probe_dir link
   # Own dir, so the cleanup below can't touch a concurrent installer's probe or
   # anything the user keeps here. If mktemp fails, stay quiet rather than guess.
   probe_dir="$(mktemp -d "${AGENTS_DIR}/.symlink-probe.XXXXXX" 2>/dev/null)" || return 0
   link="${probe_dir}/link"
-  : > "${probe_dir}/target"
-  if ln -s -- "${probe_dir}/target" "$link" 2>/dev/null && [ ! -L "$link" ]; then
+  if [ "$kind" = dir ]; then
+    mkdir "${probe_dir}/target"
+  else
+    : > "${probe_dir}/target"
+  fi
+  if make_link "${probe_dir}/target" "$link" 2>/dev/null && [ ! -L "$link" ]; then
     SYMLINKS_REAL=0
   fi
   rm -rf -- "$probe_dir"
@@ -78,7 +108,7 @@ link_one() {
   if [ -e "$dest" ] || [ -L "$dest" ]; then
     if [ -L "$dest" ] && is_ours "$dest"; then
       rm -- "$dest"
-      ln -s -- "$src" "$dest"
+      make_link "$src" "$dest"
       echo "  relink ${name}"
       PHASE_DONE=$((PHASE_DONE + 1))
       return
@@ -92,7 +122,7 @@ link_one() {
     fi
   fi
 
-  ln -s -- "$src" "$dest"
+  make_link "$src" "$dest"
   echo "  link   ${name}"
   PHASE_DONE=$((PHASE_DONE + 1))
 }
@@ -123,9 +153,11 @@ end_phase() {
 # reads as a successful no-op. A run that got its work done stays quiet.
 report_install_health() {
   if [ "$SYMLINKS_REAL" -eq 0 ]; then
-    echo "Warning: this shell copies instead of creating symlinks (typical for Git Bash on" >&2
-    echo "  Windows). The installed entries are snapshots that do not follow this repo, so" >&2
-    echo "  re-run with --force after updating it to refresh them." >&2
+    echo "Warning: this environment copies instead of linking, so the installed entries are" >&2
+    echo "  snapshots that do not follow this repo; re-run with --force after updating it to" >&2
+    echo "  refresh them. On Windows, links to single files (the rules) need Developer Mode or" >&2
+    echo "  an elevated shell, while links to directories (the skills) fall back to junctions" >&2
+    echo "  and need neither." >&2
   elif [ "$NOTHING_INSTALLED" -eq 1 ]; then
     echo "The install names are held by entries this script does not own, so the installed" >&2
     echo "  content will not follow this repo. Re-run with --force to replace those entries" >&2


### PR DESCRIPTION
On Windows both installers quietly copied instead of linking. `ln -s` in Git Bash
falls back to a copy unless the shell may create native symlinks, which takes
Developer Mode or an elevated shell. The copies never follow the repo and re-runs
skip them, so an install froze at whatever it was on its first run.

Skills are directories, so `install.sh` now falls back to `mklink /J`. A junction
needs no privilege, and MSYS reads one back as a symlink, so `readlink`, `-L` and
`rm` all behave the way the installers already assume. Hard links can't stand in
here, since NTFS has no directory hard links.

Rules are single `.md` files, which junctions don't cover, so those still copy and
still need `--force`. The docs say which case is which, and keep the one-time
`./install.sh --force` that converts an install predating junctions.

The copy detection moved out of the up-front probe into `link_one`, which checks
the entry it just created. Junctions are a per-volume feature and the two
destinations an installer writes to can sit on different ones, so a `--skills-dir`
on a network or non-NTFS drive would have copied silently while a probe in the
agents dir called linking fine.

## Verified on Windows 10, Git Bash, no Developer Mode

- fresh install links 21 skills across both layers; re-running converges with
  nothing relinked
- edits in the repo show through the installed path, and deleting a skill from the
  repo prunes it from both layers
- `rm` and `rm -rf` on a junction remove only the link and leave the target intact,
  including `rm -rf` of a parent directory holding one
- with `cmd` off `PATH` it degrades to copying and warns, in the wording that fits
  the caller
