### PR TITLE
feat(maintainer-review): put the scannable summary last, where the reader lands

### DIFF
--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.1"
+  version: "0.2"
 ---
 
 # Maintainer review
@@ -89,12 +89,25 @@ objection — with none, when the clean verdict came back unchallenged or gained
 
 ## 6. Report
 
-In chat, no file. Lead with the verdict — does it block the merge — then the findings with
-`path:line` evidence, then the comment walk. Close with what you could **not** verify and who has
-to: a review that never ran the code says so, and names what the author should test, including the
-side effects a fix for X reaches in Y.
+In chat, no file. The reader sees the tail first, so the **scannable** part goes last.
 
-Done when every finding and every walked comment has a stated position.
+**Detail first.** Every finding with its `path:line` and evidence, then the comment walk. Facts, not
+restatement; no item outgrows a short paragraph. Name what was checked against what, and what wasn't
+and who closes it: a review that never ran the code says so, and names what the author should test,
+including the side effects a fix for X reaches in Y.
+
+**Summary last** — it has to survive a glance, in this order:
+
+- the verdict: does it block the merge, and what stands in the way;
+- one line per finding and per walked comment, mirroring the detail's order, each with its
+  `path:line` (or the comment's author and date), the claim in a clause, and its position —
+  blocking, non-blocking, answered, no longer applies;
+- the one recommended next action and what it waits on.
+
+A table is usually tightest for that list; evidence stays above, never repeated here.
+
+Done when the closing summary gives every finding and every walked comment a stated position and
+ends on a recommended action.
 
 ## Acting on the PR
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -107,8 +107,8 @@ including the side effects a fix for X reaches in Y.
 
 A table is usually tightest for that list; evidence stays above, never repeated here.
 
-Done when the closing summary opens on the verdict, gives every finding and every walked comment a
-stated position, and ends on a recommended action.
+Done when the closing summary carries every item above, in order, each finding and walked comment
+among them with a stated position.
 
 ## Acting on the PR
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -102,12 +102,13 @@ including the side effects a fix for X reaches in Y.
 - one line per finding and per walked comment, mirroring the detail's order, each with its
   `path:line` (or the comment's author and date), the claim in a clause, and its position —
   blocking, non-blocking, answered, no longer applies;
+- anything still unverified and who closes it, named not restated;
 - the one recommended next action and what it waits on.
 
 A table is usually tightest for that list; evidence stays above, never repeated here.
 
-Done when the closing summary gives every finding and every walked comment a stated position and
-ends on a recommended action.
+Done when the closing summary opens on the verdict, gives every finding and every walked comment a
+stated position, and ends on a recommended action.
 
 ## Acting on the PR
 


### PR DESCRIPTION
## What and why

Ran `maintainer-review` on a real PR and the report came back at about three screens of prose. All
the right information, just unreadable as a verdict: you scroll and scroll and never get a list you
can act on.

Section 6 was the cause. It named the report's ingredients (verdict, findings, comment walk, what
you couldn't verify) but said nothing about shape, so each ingredient rendered as prose and nothing
capped an item's length.

It now splits in two. Detail first, one short paragraph per item. Then a closing summary: the
verdict, one line per finding and per walked comment carrying its position, anything still
unverified and who closes it, and the one recommended next action.

## Decisions worth knowing

The summary goes last, not first, which reverses what the section said before ("Lead with the
verdict"). In a terminal the tail of the session is what you actually see when you look back at it,
so a verdict at the top is the part guaranteed to scroll away.

No summary at the top as well. Two copies would just be the sprawl again with a table bolted on, so
the scannable block lives in one place and the evidence above it is never repeated.

Version goes to 0.2 rather than 1.0. The skill did its job on the real run, but the run also turned
up this, so it felt early to call it stable.
