### PR TITLE
feat: add split-plan-tasks and execute-plan-tasks skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ fetch a ticket, refine it, plan it, then let a fresh session execute it and cons
 - **[create-implementation-plan](./skills/create-implementation-plan/SKILL.md)** — define the
   "how" of a task: turn the requirements into an implementation plan, settling the technical
   decisions together, then save it for a fresh session to execute.
+- **[split-plan-tasks](./skills/split-plan-tasks/SKILL.md)** — break a plan into individually
+  reviewable tasks grouped into PR-sized batches, appended to the plan file for a fresh session to
+  execute one at a time.
 - **[create-manual-test-instructions](./skills/create-manual-test-instructions/SKILL.md)** —
   derive manual test steps from a ticket or requirements file, useful for the developer or QA.
 - **[handover](./skills/handover/SKILL.md)** — package a finished change for its reviewers:
@@ -200,6 +203,7 @@ flowchart TD
   check_impl["check-ticket-implementation"] --> fetch_ticket
   refine --> manual["create-manual-test-instructions"]
   refine --> plan["create-implementation-plan"]
+  plan --> split["split-plan-tasks"]
   plan --> handover["handover"]
   handover --> express
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Maintenance to run from time to time, keeping your setup tidy and your context s
 
 A daily routine for any programming task, following the
 [RPAC workflow](https://medium.com/engineering-in-the-age-of-ai/the-refine-plan-act-pattern-for-agentic-ai-coding-59ee013e4427):
-fetch a ticket, refine it, plan it, then let a fresh session execute it and consolidate the changes.
+fetch a ticket, refine it, plan it, split the plan into small tasks, then let a fresh session
+execute them one at a time and consolidate the changes.
 
 - **[fetch-ticket](./skills/fetch-ticket/SKILL.md)** — download a ticket from any tracker
   (e.g. GitHub, Jira, Azure DevOps) and save it as a self-contained markdown file.
@@ -54,6 +55,9 @@ fetch a ticket, refine it, plan it, then let a fresh session execute it and cons
 - **[split-plan-tasks](./skills/split-plan-tasks/SKILL.md)** — break a plan into individually
   reviewable tasks grouped into PR-sized batches, appended to the plan file for a fresh session to
   execute one at a time.
+- **[execute-plan-tasks](./skills/execute-plan-tasks/SKILL.md)** — execute one task of that
+  breakdown at a time: implement it, verify it, tick it off in the plan, and hand it back for
+  review before the next.
 - **[create-manual-test-instructions](./skills/create-manual-test-instructions/SKILL.md)** —
   derive manual test steps from a ticket or requirements file, useful for the developer or QA.
 - **[handover](./skills/handover/SKILL.md)** — package a finished change for its reviewers:
@@ -204,6 +208,7 @@ flowchart TD
   refine --> manual["create-manual-test-instructions"]
   refine --> plan["create-implementation-plan"]
   plan --> split["split-plan-tasks"]
+  split --> execute["execute-plan-tasks"]
   plan --> handover["handover"]
   handover --> express
 

--- a/skills/execute-plan-tasks/SKILL.md
+++ b/skills/execute-plan-tasks/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: execute-plan-tasks
+description: Execute one task from a plan's task breakdown, verify it, tick it off, and hand back for review before the next one.
+disable-model-invocation: true
+type: flow
+license: MIT
+metadata:
+  version: "0.1"
+---
+
+# Execute plan tasks
+
+One task per run — implement it, verify it, tick it, stop. The review between tasks is the point;
+never carry on into the next.
+
+Invocation: `/execute-plan-tasks <plan-path> [task-id]`
+
+## Pick the task
+
+Read the plan whole — summary, conventions and overrides, the steps the task cites, acceptance
+criteria — then its `## Tasks` section. Ambiguous or missing plan path → ask. Several task sections
+→ ask which one this run works from. No task section → stop and point at `/split-plan-tasks`.
+
+`task-id` given → that task; none → the first unticked one in order. A range or a whole group → run
+its first task only, saying the rest need their own runs; a task already ticked → say so and ask
+whether to redo it. Its dependencies — earlier tasks in its group, plus every group its *Depends
+on* names — must be ticked; any that isn't → name it and ask before proceeding.
+
+Done when the chosen task, its steps, its acceptance criteria and its dependency state are stated.
+
+## Execute
+
+- **Scope is the task's steps, nothing else**: no work belonging to a later task, no drive-by
+  refactors. Work the plan calls for that no task covers → report it, don't absorb it.
+- The plan's conventions and overrides bind every task, this one included.
+- **Never guess.** What the code settles, settle by reading it; what it doesn't goes to the user as
+  one question carrying your recommendation. Append each settled deviation from the plan, and its
+  why, as one line to the decisions log beside the plan (`<slug>.DECISIONS.md`), creating it if
+  absent.
+- Blocked outright — a step the codebase contradicts, an unmet prerequisite — → stop, leave the
+  task unticked, report what blocks it.
+
+Done when every step of the task is implemented, or its blocker reported.
+
+## Verify
+
+Run the task's *Done when* check, then the validation the project's governing docs name — failing
+that, its toolchain's lint, tests and build; nothing runnable → say so rather than invent a
+command. Fix what this task broke; a failure that predates it or lands outside its scope is
+reported, never fixed silently.
+
+Done when both pass, or every remaining failure is reported with why it stands.
+
+## Close
+
+Tick the task `- [ ]` → `- [x]`, plus each acceptance criterion it *Satisfies* whose every
+satisfying task is now ticked — the plan's only edits, made once verification passed; name the ACs
+still partly open. Then print the files touched, any deviation logged, and the task's *Commit*
+subject (absent → propose one in the repo's style) to commit once the change is reviewed. Finally
+hand off the next unticked task as a single copy-pasteable launch command — session name and prompt
+combined, in the launch syntax of the agent tool in use (vendor-agnostic — `claude` below is only
+the example):
+
+```
+claude --name execute-tasks-<slug> "/execute-plan-tasks <plan-path> <next-task-id>"
+```
+
+Then offer the alternative — clearing the current session instead (vendor-agnostic — `/clear` is
+only the example):
+
+OR /clear and run:
+
+```
+/execute-plan-tasks <plan-path> <next-task-id>
+```
+
+When the finished task completes its group, say so first — the group is a PR — and point at the
+next group's first task. When no task is left, say the plan is done instead of handing off.
+
+Done when the touched files, the commit subject and either both next-task commands or the
+plan-complete line are printed.
+
+## Boundaries
+
+- Never commit, push, or open a PR.
+- The plan file's only changes are those checkboxes; the decisions log is appended to, never
+  rewritten.

--- a/skills/execute-plan-tasks/SKILL.md
+++ b/skills/execute-plan-tasks/SKILL.md
@@ -23,8 +23,8 @@ criteria — then its `## Tasks` section. Ambiguous or missing plan path → ask
 
 `task-id` given → that task; none → the first unticked one in order. A range or a whole group → run
 its first task only, saying the rest need their own runs; a task already ticked → say so and ask
-whether to redo it. Its dependencies — earlier tasks in its group, plus every group its *Depends
-on* names — must be ticked; any that isn't → name it and ask before proceeding.
+whether to redo it. Its dependencies — earlier tasks in its group, plus every task in each group its
+*Depends on* line names — must be ticked; name any unticked dependency and ask before proceeding.
 
 Done when the chosen task, its steps, its acceptance criteria and its dependency state are stated.
 

--- a/skills/split-plan-tasks/SKILL.md
+++ b/skills/split-plan-tasks/SKILL.md
@@ -70,7 +70,7 @@ tool in use (vendor-agnostic — `claude` below is only the example), naming the
 `execute-tasks-<slug>` after the plan's slug:
 
 ```
-claude --name execute-tasks-<slug> "Execute task 1.1 of <plan-path>, then stop for review"
+claude --name execute-tasks-<slug> "/execute-plan-tasks <plan-path> 1.1"
 ```
 
 Then offer the alternative — clearing the current session instead (vendor-agnostic — `/clear` is
@@ -79,7 +79,7 @@ only the example):
 OR /clear and run:
 
 ```
-Execute task 1.1 of <plan-path>, then stop for review
+/execute-plan-tasks <plan-path> 1.1
 ```
 
 Done when the path, the tally, and both commands are printed.

--- a/skills/split-plan-tasks/SKILL.md
+++ b/skills/split-plan-tasks/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: split-plan-tasks
+description: Split a plan into small, individually reviewable tasks grouped into PR-sized batches, appended as a task section at the end of the plan file.
+disable-model-invocation: true
+type: flow
+license: MIT
+metadata:
+  version: "0.1"
+---
+
+# Split plan into tasks
+
+Append a task breakdown to a plan so the work lands in small increments — one task, then a review,
+a correction pass, a commit — instead of one sweep. Authoring only: executing the tasks is a later,
+separate session.
+
+Invocation: `/split-plan-tasks <plan-path>`
+
+## Read the plan
+
+Ambiguous or missing path → ask. A plan with numbered steps and an acceptance-criteria checklist
+splits best; any plan markdown works — reference tasks to headings when steps aren't numbered, and
+drop the AC line when there is no such checklist.
+
+A plan already carrying a task section → **stop and ask** which the user wants: replace it, add a
+second one beside it, or carry the ticked tasks forward and reformulate only the remaining work.
+
+Done when the plan is read and, where a section already existed, the user has chosen.
+
+## Work out the split
+
+- **Task** — the smallest chunk that leaves the project building and its tests passing, so it can be
+  reviewed and committed on its own. Steps that only make sense together are one task, never two.
+- **Group** — one PR: independently mergeable, delivering something coherent. Order the groups and
+  state each one's dependency on earlier groups.
+- Respect the plan's ordering: a task never precedes what it depends on.
+- Both ways: every plan step and every acceptance criterion lands in exactly one task, and no task
+  invents work the plan doesn't call for.
+
+Present the whole breakdown with the obvious calls already decided, and walk only the genuinely
+doubtful boundaries as individual questions, each carrying your recommendation. One approval gate
+before writing anything.
+
+Done when every step and criterion is placed and the user has approved the breakdown.
+
+## Append the section
+
+At the end of the plan file — the only edit made:
+
+```markdown
+## Tasks
+
+### Group 1 — <what this PR delivers>
+
+*Depends on* nothing
+
+- [ ] **1.1 <short imperative>** — steps 2–3
+  - *Done when* <what to run or look at to confirm it landed>
+  - *Satisfies* AC-1, AC-4
+  - *Commit* `<suggested subject>`
+```
+
+Done when every task from the approved breakdown is in the file.
+
+## Close
+
+State the plan's project-relative path and the tally (tasks, groups). Then hand off as a single
+copy-pasteable launch command — session name and prompt combined, in the launch syntax of the agent
+tool in use (vendor-agnostic — `claude` below is only the example), naming the session
+`execute-tasks-<slug>` after the plan's slug:
+
+```
+claude --name execute-tasks-<slug> "Execute task 1.1 of <plan-path>, then stop for review"
+```
+
+Then offer the alternative — clearing the current session instead (vendor-agnostic — `/clear` is
+only the example):
+
+OR /clear and run:
+
+```
+Execute task 1.1 of <plan-path>, then stop for review
+```
+
+Done when the path, the tally, and both commands are printed.
+
+## Boundaries
+
+- The appended section is the only edit: never rewrite the plan's existing content, never touch
+  source files.
+- No implementation — the breakdown is the output.

--- a/skills/split-plan-tasks/SKILL.md
+++ b/skills/split-plan-tasks/SKILL.md
@@ -34,6 +34,11 @@ Done when the plan is read and, where a section already existed, the user has ch
 - **Group** — one PR: independently mergeable, delivering something coherent. Order the groups and
   state each one's dependency on earlier groups.
 - Respect the plan's ordering: a task never precedes what it depends on.
+- **Front-load a hands-on slice.** Among dependency-legal orderings, prefer the one whose first
+  group leaves the app exercisable by hand — a screen to click where the plan touches a UI, else a
+  command to run or an endpoint to hit — accepting a larger first group when that's what makes the
+  slice whole, never scaffolding the plan doesn't call for. When nothing early gets there, say so
+  when presenting.
 - Both ways: every plan step and every acceptance criterion lands in exactly one task, and no task
   invents work the plan doesn't call for.
 
@@ -41,7 +46,8 @@ Present the whole breakdown with the obvious calls already decided, and walk onl
 doubtful boundaries as individual questions, each carrying your recommendation. One approval gate
 before writing anything.
 
-Done when every step and criterion is placed and the user has approved the breakdown.
+Done when every step and criterion is placed, the first group is exercisable or you've said why
+not, and the user has approved the breakdown.
 
 ## Append the section
 
@@ -53,12 +59,15 @@ At the end of the plan file — the only edit made:
 ### Group 1 — <what this PR delivers>
 
 *Depends on* nothing
+*Try it* <what to open or run to exercise the app>
 
 - [ ] **1.1 <short imperative>** — steps 2–3
   - *Done when* <what to run or look at to confirm it landed>
   - *Satisfies* AC-1, AC-4
   - *Commit* `<suggested subject>`
 ```
+
+*Try it* goes only on the first group that leaves the app exercisable.
 
 Done when every task from the approved breakdown is in the file.
 


### PR DESCRIPTION
Adds two skills: one splits a plan into small tasks, the other runs them one at a time.

`/split-plan-tasks` takes a plan file and appends a task breakdown: small tasks that each leave the project building and its tests passing, grouped into PR-sized batches with the dependencies between groups stated. It only ever appends the `## Tasks` section, never rewrites the plan and never touches source files. If the plan already carries a task section it stops and asks what you want to do with it.

`/execute-plan-tasks` picks up from there and runs a single task. It implements that task's steps and nothing else, runs the task's own check plus the project's validation, ticks the task off in the plan along with any acceptance criterion its tasks now all cover, and stops. Whatever the plan doesn't settle comes back to you as a question, and every settled deviation goes into the decisions file next to the plan. It never commits: it prints the suggested commit subject and a copy-pasteable command to launch the next task in a fresh session.

The point is to stop executing a plan in one sweep. You run one task, review it, commit, then launch the next.

The rest is the README catalog entries and the graph edge, since every other skill has one.
