### PR TITLE
feat(write-realistic-texts): gate publishing on a go-ahead for the wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ installed separately from the skills.
   something a skill or doc governs, offer to persist the lesson via
   [self-improve](./skills/self-improve/SKILL.md).
 - **[write-realistic-texts](./rules/write-realistic-texts.md)** — make text other people will
-  read sound natural, and get the user's go-ahead on the wording before publishing it, code
-  comments and plain commit messages aside.
+  read sound natural, and get the user's go-ahead on the wording before publishing it; text that
+  ships inside the change needs no go-ahead.
 
 One more rule for non-English speakers ships as a copy-paste snippet rather than a file, since it 
 needs the language filled in — [use-my-mothertongue](./docs/use-my-mothertongue-rule.md) makes  

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ installed separately from the skills.
   something a skill or doc governs, offer to persist the lesson via
   [self-improve](./skills/self-improve/SKILL.md).
 - **[write-realistic-texts](./rules/write-realistic-texts.md)** — make text other people will
-  read sound natural, and get the user's go-ahead on the wording before publishing it; text that
-  ships inside the change needs no go-ahead.
+  read sound natural, and get the user's go-ahead on the wording before publishing the texts it
+  names.
 
 One more rule for non-English speakers ships as a copy-paste snippet rather than a file, since it 
 needs the language filled in — [use-my-mothertongue](./docs/use-my-mothertongue-rule.md) makes  

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ installed separately from the skills.
   something a skill or doc governs, offer to persist the lesson via
   [self-improve](./skills/self-improve/SKILL.md).
 - **[write-realistic-texts](./rules/write-realistic-texts.md)** — make text other people will
-  read sound natural, no AI-generated nonsense.
+  read sound natural, and get the user's go-ahead on the wording before publishing it.
 
 One more rule for non-English speakers ships as a copy-paste snippet rather than a file, since it 
 needs the language filled in — [use-my-mothertongue](./docs/use-my-mothertongue-rule.md) makes  

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ installed separately from the skills.
   something a skill or doc governs, offer to persist the lesson via
   [self-improve](./skills/self-improve/SKILL.md).
 - **[write-realistic-texts](./rules/write-realistic-texts.md)** — make text other people will
-  read sound natural, and get the user's go-ahead on the wording before publishing it outside
-  the change.
+  read sound natural, and get the user's go-ahead on the wording before publishing it, code
+  comments and plain commit messages aside.
 
 One more rule for non-English speakers ships as a copy-paste snippet rather than a file, since it 
 needs the language filled in — [use-my-mothertongue](./docs/use-my-mothertongue-rule.md) makes  

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ installed separately from the skills.
   something a skill or doc governs, offer to persist the lesson via
   [self-improve](./skills/self-improve/SKILL.md).
 - **[write-realistic-texts](./rules/write-realistic-texts.md)** — make text other people will
-  read sound natural, and get the user's go-ahead on the wording before publishing it.
+  read sound natural, and get the user's go-ahead on the wording before publishing it outside
+  the change.
 
 One more rule for non-English speakers ships as a copy-paste snippet rather than a file, since it 
 needs the language filled in — [use-my-mothertongue](./docs/use-my-mothertongue-rule.md) makes  

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -1,6 +1,6 @@
 ---
 name: write-realistic-texts
-description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing; replies to the user in session are exempt, and the rule lists what else is.
+description: Texts other people will read follow the use-conversational-language skill, and the ones the rule names need the user's go-ahead on their wording before publishing; replies to the user in session are exempt.
 ---
 
 Whenever writing text that other people will read as if the user wrote it — commit messages,
@@ -17,11 +17,9 @@ apply there, not conversational voice.
 Agent-facing texts (plans, analyses, specs, skills, rules) are exempt; there, completeness and
 unambiguity beat brevity.
 
-Publishing a text that will read as the user's own needs an EXPLICIT go-ahead on the concrete
-wording first: PR and issue comments, PR descriptions, review bodies, release notes, chat messages,
-commit trailers crediting other people, anything sent to an external service. Code comments, plain
-commit messages and documentation edits need no go-ahead, they ship inside the change the user
-already reviews.
+Publishing any of these needs an EXPLICIT go-ahead on the concrete wording first: PR and issue
+comments, PR descriptions, review bodies, release notes, chat messages, commit trailers crediting
+other people, anything sent to an external service.
 
 Naming the action does not approve the wording: "approve and add the label", "comment and close"
 authorize those actions and nothing more. Draft it, show it, wait. Other named actions proceed

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -1,6 +1,6 @@
 ---
 name: write-realistic-texts
-description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing anything that does not arrive with the change; private agent-user chat and official docs are exempt.
+description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing, except code comments and plain commit messages; private agent-user chat and official docs are exempt from both.
 ---
 
 Whenever writing text that other people will read as if the user wrote it — commit messages,
@@ -11,8 +11,8 @@ similar — you must actually invoke the `use-conversational-language` skill and
 Replies to the user in the current session are private agent-user communication, out of scope
 however conversational they sound.
 
-Documentation (README and similar) is out of scope: written prose conventions apply there, not
-conversational voice.
+Documentation (README and similar) is out of scope for the voice rule: written prose conventions
+apply there, not conversational voice.
 
 Agent-facing texts (plans, analyses, specs, skills, rules) are exempt; there, completeness and
 unambiguity beat brevity.
@@ -24,8 +24,8 @@ plain commit messages need no go-ahead, they land in the change the user already
 
 Naming the action does not approve the wording: "approve and add the label", "comment and close"
 authorize those actions and nothing more. Draft it, show it, wait. Other named actions proceed
-meanwhile unless the instruction ordered them after the text, so "comment, then approve and merge"
-holds the whole chain at the comment.
+meanwhile unless the instruction ordered them after the text or the action itself publishes it, so
+"comment, then approve and merge" holds the whole chain at the comment.
 
 Submit PR approvals with an empty body; anything worth saying goes as a separate comment. A
 go-ahead covers the wording it was given for, never the next text. Never write opinions,

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -1,6 +1,6 @@
 ---
 name: write-realistic-texts
-description: Texts other people will read follow the use-conversational-language skill and need the user's go-ahead on the wording before publishing; private agent-user chat and official docs are exempt.
+description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing anything that does not arrive with the change; private agent-user chat and official docs are exempt.
 ---
 
 Whenever writing text that other people will read as if the user wrote it — commit messages,
@@ -17,15 +17,16 @@ conversational voice.
 Agent-facing texts (plans, analyses, specs, skills, rules) are exempt; there, completeness and
 unambiguity beat brevity.
 
-Publishing one needs an EXPLICIT go-ahead on the concrete wording first: PR and issue comments,
-review bodies, release notes, chat messages, commit trailers crediting other people, anything sent
-to an external service. Code comments and plain commit messages are out of scope, they land in the
-change the user already reviews.
+Publishing a text that will read as the user's own needs an EXPLICIT go-ahead on the concrete
+wording first: PR and issue comments, PR descriptions, review bodies, release notes, chat messages,
+commit trailers crediting other people, anything sent to an external service. Code comments and
+plain commit messages need no go-ahead, they land in the change the user already reviews.
 
-Naming the action does not approve the wording: "approve and add the label", "comment and close",
-"open the PR" authorize those actions and nothing more. Draft it, show it, wait. Other named
-actions proceed meanwhile only when reversible and not ordered after the text, so "comment, then
-approve and merge" holds the whole chain at the comment.
+Naming the action does not approve the wording: "approve and add the label", "comment and close"
+authorize those actions and nothing more. Draft it, show it, wait. Other named actions proceed
+meanwhile unless the instruction ordered them after the text, so "comment, then approve and merge"
+holds the whole chain at the comment.
 
-A go-ahead is one-off: approval of one comment, commit or file is never approval of the next.
-Never write opinions, verdicts, or a review in the user's voice that the user did not ask for.
+Submit PR approvals with an empty body; anything worth saying goes as a separate comment. A
+go-ahead covers the wording it was given for, never the next text. Never write opinions,
+verdicts, or a review in the user's voice that the user did not ask for.

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -1,6 +1,6 @@
 ---
 name: write-realistic-texts
-description: Texts other people will read follow the use-conversational-language skill; private agent-user chat and official docs are exempt.
+description: Texts other people will read follow the use-conversational-language skill and need the user's go-ahead on the wording before publishing; private agent-user chat and official docs are exempt.
 ---
 
 Whenever writing text that other people will read as if the user wrote it — commit messages,
@@ -16,3 +16,16 @@ conversational voice.
 
 Agent-facing texts (plans, analyses, specs, skills, rules) are exempt; there, completeness and
 unambiguity beat brevity.
+
+Publishing one needs an EXPLICIT go-ahead on the concrete wording first: PR and issue comments,
+review bodies, release notes, chat messages, commit trailers crediting other people, anything sent
+to an external service. Code comments and plain commit messages are out of scope, they land in the
+change the user already reviews.
+
+Naming the action does not approve the wording: "approve and add the label", "comment and close",
+"open the PR" authorize those actions and nothing more. Draft it, show it, wait. Other named
+actions proceed meanwhile only when reversible and not ordered after the text, so "comment, then
+approve and merge" holds the whole chain at the comment.
+
+A go-ahead is one-off: approval of one comment, commit or file is never approval of the next.
+Never write opinions, verdicts, or a review in the user's voice that the user did not ask for.

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -1,6 +1,6 @@
 ---
 name: write-realistic-texts
-description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing, except code comments and plain commit messages; private agent-user chat and official docs are exempt from both.
+description: Texts other people will read follow the use-conversational-language skill, and need the user's go-ahead on the wording before publishing; replies to the user in session are exempt, and the rule lists what else is.
 ---
 
 Whenever writing text that other people will read as if the user wrote it — commit messages,
@@ -19,8 +19,9 @@ unambiguity beat brevity.
 
 Publishing a text that will read as the user's own needs an EXPLICIT go-ahead on the concrete
 wording first: PR and issue comments, PR descriptions, review bodies, release notes, chat messages,
-commit trailers crediting other people, anything sent to an external service. Code comments and
-plain commit messages need no go-ahead, they land in the change the user already reviews.
+commit trailers crediting other people, anything sent to an external service. Code comments, plain
+commit messages and documentation edits need no go-ahead, they ship inside the change the user
+already reviews.
 
 Naming the action does not approve the wording: "approve and add the label", "comment and close"
 authorize those actions and nothing more. Draft it, show it, wait. Other named actions proceed

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -18,8 +18,8 @@ Agent-facing texts (plans, analyses, specs, skills, rules) are exempt; there, co
 unambiguity beat brevity.
 
 Publishing any of these needs an EXPLICIT go-ahead on the concrete wording first: PR and issue
-comments, PR descriptions, review bodies, release notes, chat messages, commit trailers crediting
-other people, anything sent to an external service.
+comments, PR descriptions, review bodies, release notes, chat messages, wiki and tracker pages,
+commit trailers crediting other people.
 
 Naming the action does not approve the wording: "approve and add the label", "comment and close"
 authorize those actions and nothing more. Draft it, show it, wait. Other named actions proceed


### PR DESCRIPTION
I've been running this as a local rule outside the toolkit and want to stop depending on
local-only rules, so it moves in here. Nothing in the toolkit covered it.

What prompted the wording fix: I told the agent "post the comment, then approve and merge" on
a PR I was reviewing. It approved and merged first, then showed me the comment draft. The rule
it was following let the other named actions go ahead while the text waited, with no condition
on that at all.

write-realistic-texts is the right host because its opening already defines the scope this
needs, text other people read as if I wrote it, and it already carves out private replies, docs
and agent-facing text.

On top of the voice requirement it already carried:

A closed list of texts needs an explicit go-ahead on the concrete wording before publishing.
PR and issue comments, PR descriptions, review bodies, release notes, chat messages, wiki and
tracker pages, and trailers crediting other people. Code comments and plain commit messages
aren't on the list, so they need no go-ahead.

Naming the action doesn't approve the wording, and other named actions only run ahead of the
text when the instruction didn't order them after it and the action doesn't itself publish it.

PR approvals go in with an empty body, a go-ahead covers only the wording it was given for,
and no unrequested opinions in my voice.

Left out one part of the local rule, "do exactly what the instruction names", which the harness
states itself now. The empty-body clause is duplicated from maintainer-review on purpose, since
rules install standalone.
