### PR TITLE
feat: auto update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ be self-contained and generic — reusable in any project — so avoid project-s
 assumptions. Rules are opt-in: a skill must work correctly with no rules installed, so never fix
 or extend a skill by adding a rule it depends on.
 
-Skill test harnesses live in `test/<skill-name>/` — repo-internal, never installed; their `runs/`
-output dirs are gitignored. Planning documents go in `.agents/plans/` (gitignored).
+Test harnesses, for a skill or an install script, live in `test/<name>/` — repo-internal, never
+installed; their `runs/` output dirs are gitignored. Planning documents go in `.agents/plans/`
+(gitignored).
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Update in one command:
 cd agent-toolkit && git pull && ./install.sh
 ```
 
+On Claude Code the install also registers a hook that runs that update for you once a day; an
+install made before it needs the command above once to pick it up
+([docs/auto-update.md](./docs/auto-update.md)).
+
 On Windows the skills link through junctions, so the update command above works as-is, though an
 install predating them needs one `./install.sh --force` to convert. The rules are copied instead
 and need `--force` every time (see [Windows](./docs/install-skills.md#windows)).

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -24,9 +24,10 @@ thing it said.
 
 That last point is what to weigh against
 [pillar 3](./core-philosophy.md#pillar-3-human-in-the-loop). It stays on by default because the
-installer announces it, one flag opts out, and it never puts anything in the model's context: what
-it changes is the content of skills and rules you already opted into, exactly what
-`git pull && ./install.sh` does by hand.
+installer announces it, one flag opts out, and the hook itself adds nothing to the model's
+context: its messages go to you, not the model. What changes is what `git pull && ./install.sh`
+would change by hand — the content of the skills and rules you opted into, plus whatever the repo
+added or dropped since.
 
 ## Moving or deleting the clone
 
@@ -42,6 +43,8 @@ it they skip the links still pointing at the old path as entries they do not own
   "$CLAUDE_CONFIG_DIR/rules"` to get wired up; the hook is registered for Claude's own directories
   only.
 - Hooks from user settings do not run in a folder until its workspace-trust dialog is accepted.
+- One hook per settings file: an install from another clone points it at that clone, as it does
+  the links, and `--no-auto-update` from that clone removes it.
 - Windows Git Bash: a profile that echoes unconditionally prepends its output to the hook's, so the
   output no longer starts with `{`, and all of it is injected into the model's context. Keep
   profile echoes behind an interactive check.
@@ -54,14 +57,15 @@ it they skip the links still pointing at the old path as entries they do not own
 The installers only know Claude Code. The recipes below were verified against each agent's docs on
 2026-09-06; `<clone>` is this clone's absolute path. The ones that log to a file resolve it through
 `git rev-parse`, since in a linked worktree or a submodule `.git` is a file and nothing can be
-written beneath it.
+written beneath it. The directory they log to is created by the installers, so run one for the
+agent first — that run is also what the hook will replay.
 
 ### Gemini CLI
 
 In `~/.gemini/settings.json` (`$GEMINI_CLI_HOME` when set), add to `hooks.SessionStart`:
 
 ```json
-{ "matcher": "startup", "hooks": [{ "type": "command", "command": "bash '<clone>/lib/auto-update.sh' --json", "timeout": 10000 }] }
+{ "matcher": "startup", "hooks": [{ "type": "command", "command": "bash '<clone>/lib/auto-update.sh' --json", "timeout": 20000 }] }
 ```
 
 `timeout` is in **milliseconds** here, and `name` is optional. The hook is synchronous but never
@@ -73,7 +77,7 @@ user — so `--json` serves it unchanged.
 `~/.copilot/hooks/agent-toolkit.json` (`$COPILOT_HOME/hooks/` when set):
 
 ```json
-{ "version": 1, "hooks": { "sessionStart": [{ "type": "command", "bash": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeoutSec": 10 }] } }
+{ "version": 1, "hooks": { "sessionStart": [{ "type": "command", "bash": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeoutSec": 20 }] } }
 ```
 
 Stdout is parsed as hook JSON, non-JSON is discarded, and nothing reaches you on exit 0 — hence
@@ -86,7 +90,7 @@ for the hook is undocumented.
 `~/.cursor/hooks.json`, for the desktop app (CLI support is undocumented):
 
 ```json
-{ "version": 1, "hooks": { "sessionStart": [{ "command": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeout": 10 }] } }
+{ "version": 1, "hooks": { "sessionStart": [{ "command": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeout": 20 }] } }
 ```
 
 It runs from `~/.cursor/`, fire-and-forget, and handles JSON stdout (plain text is undocumented),

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -52,7 +52,9 @@ it they skip the links still pointing at the old path as entries they do not own
 ## Other agents
 
 The installers only know Claude Code. The recipes below were verified against each agent's docs on
-2026-09-06; `<clone>` is this clone's absolute path.
+2026-09-06; `<clone>` is this clone's absolute path. The ones that log to a file resolve it through
+`git rev-parse`, since in a linked worktree or a submodule `.git` is a file and nothing can be
+written beneath it.
 
 ### Gemini CLI
 
@@ -71,7 +73,7 @@ user — so `--json` serves it unchanged.
 `~/.copilot/hooks/agent-toolkit.json` (`$COPILOT_HOME/hooks/` when set):
 
 ```json
-{ "version": 1, "hooks": { "sessionStart": [{ "type": "command", "bash": "bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log'", "timeoutSec": 10 }] } }
+{ "version": 1, "hooks": { "sessionStart": [{ "type": "command", "bash": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeoutSec": 10 }] } }
 ```
 
 Stdout is parsed as hook JSON, non-JSON is discarded, and nothing reaches you on exit 0 — hence
@@ -84,7 +86,7 @@ for the hook is undocumented.
 `~/.cursor/hooks.json`, for the desktop app (CLI support is undocumented):
 
 ```json
-{ "version": 1, "hooks": { "sessionStart": [{ "command": "bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log'", "timeout": 10 }] } }
+{ "version": 1, "hooks": { "sessionStart": [{ "command": "bash '<clone>/lib/auto-update.sh' >> \"$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log\"", "timeout": 10 }] } }
 ```
 
 It runs from `~/.cursor/`, fire-and-forget, and handles JSON stdout (plain text is undocumented),
@@ -104,7 +106,7 @@ no documented output handling — use the fallback below.
 A cron entry:
 
 ```sh
-@daily bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log' 2>/dev/null
+@daily bash '<clone>/lib/auto-update.sh' >> "$(git -C '<clone>' rev-parse --absolute-git-dir)/agent-toolkit/messages.log" 2>/dev/null
 ```
 
 or a launchd agent with `StartInterval` 86400 running the same command.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -1,0 +1,107 @@
+# Auto-update
+
+Once installed, the clone keeps itself current. A daily `SessionStart` hook runs
+[`lib/auto-update.sh`](../lib/auto-update.sh), which fetches, fast-forwards the clone, and replays
+the installer runs it recorded, so the installed skills and rules follow the repo. Both installers
+register the hook when they detect Claude Code; `--no-auto-update` turns it off for good,
+`--auto-update` turns it back on.
+
+State lives in `<clone>/.git/agent-toolkit/` — the real git dir, so a linked worktree or a
+submodule gets its own: what to replay, when the next run is due, the last run's log, and the last
+thing it said.
+
+## What it does, and does not do
+
+- Fast-forward only. A clone that is dirty, detached, without an upstream, off the default branch,
+  or diverged is left alone, with one line saying so and naming the fix.
+- At most one run a day, and silent whatever the outcome: the only thing it prints is a problem
+  you have to fix, once per problem. Git and installer output goes to the log.
+- Never `--force`, so an entry the installers do not own is never replaced.
+- It does replay the installers, so an update can add skills and rules, or drop ones the repo
+  removed. Rules are always-on, so that changes how your agent behaves.
+
+That last point is what to weigh against
+[pillar 3](./core-philosophy.md#pillar-3-human-in-the-loop). It stays on by default because the
+installer announces it, one flag opts out, and it never puts anything in the model's context: what
+it changes is the content of skills and rules you already opted into, exactly what
+`git pull && ./install.sh` does by hand.
+
+## Moving or deleting the clone
+
+Run both installers with `--no-auto-update` before deleting the clone. If it is already gone,
+delete the `hooks.SessionStart` handler whose command contains `/lib/auto-update.sh` from
+`~/.claude/settings.json` by hand, or Claude Code reports a failing hook at every startup. A clone
+that moved is fixed by re-running the installers from the new place.
+
+## Notes
+
+- With `CLAUDE_CONFIG_DIR` set, pass `--skills-dir "$CLAUDE_CONFIG_DIR/skills"` and `--rules-dir
+  "$CLAUDE_CONFIG_DIR/rules"` to get wired up; the hook is registered for Claude's own directories
+  only.
+- Hooks from user settings do not run in a folder until its workspace-trust dialog is accepted.
+- Windows Git Bash: a profile that echoes unconditionally prepends its output to the hook's, so the
+  output no longer starts with `{`, and all of it is injected into the model's context. Keep
+  profile echoes behind an interactive check.
+- Installing through the Claude Code plugin marketplace is a different mechanism with its own
+  updates: third-party marketplaces have auto-update **off** by default, switch it on under
+  `/plugin` → Marketplaces → Enable auto-update.
+
+## Other agents
+
+The installers only know Claude Code. The recipes below were verified against each agent's docs on
+2026-09-06; `<clone>` is this clone's absolute path.
+
+### Gemini CLI
+
+In `~/.gemini/settings.json` (`$GEMINI_CLI_HOME` when set), add to `hooks.SessionStart`:
+
+```json
+{ "matcher": "startup", "hooks": [{ "type": "command", "command": "bash '<clone>/lib/auto-update.sh' --json", "timeout": 10000 }] }
+```
+
+`timeout` is in **milliseconds** here, and `name` is optional. The hook is synchronous but never
+blocks startup on its output, stdout must be one JSON object, and `systemMessage` is shown to the
+user — so `--json` serves it unchanged.
+
+### Copilot CLI
+
+`~/.copilot/hooks/agent-toolkit.json` (`$COPILOT_HOME/hooks/` when set):
+
+```json
+{ "version": 1, "hooks": { "sessionStart": [{ "type": "command", "bash": "bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log'", "timeoutSec": 10 }] } }
+```
+
+Stdout is parsed as hook JSON, non-JSON is discarded, and nothing reaches you on exit 0 — hence
+plain mode and the redirect, with the stuck and error lines landing in that file. (`powershell` is
+the optional sibling of `bash`; `command` is the cross-platform fallback.) Whether the CLI waits
+for the hook is undocumented.
+
+### Cursor
+
+`~/.cursor/hooks.json`, for the desktop app (CLI support is undocumented):
+
+```json
+{ "version": 1, "hooks": { "sessionStart": [{ "command": "bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log'", "timeout": 10 }] } }
+```
+
+It runs from `~/.cursor/`, fire-and-forget, and handles JSON stdout (plain text is undocumented),
+hence the redirect again. Cursor can also load Claude Code hooks once third-party configs are
+enabled in its settings (Rules, Skills, Subagents → include third-party configs) and the feature
+is on for your account; the Claude entry then fires there too, and the lock and the daily stamp
+absorb the double run.
+
+### OpenCode
+
+No shell-command hook. Plugins (`~/.config/opencode/plugins/*.js`, or `OPENCODE_CONFIG_DIR`)
+receive a `session.created` event and a `$` shell API, but that event has no documented example and
+no documented output handling — use the fallback below.
+
+### No hook at all
+
+A cron entry:
+
+```sh
+@daily bash '<clone>/lib/auto-update.sh' >> '<clone>/.git/agent-toolkit/messages.log' 2>/dev/null
+```
+
+or a launchd agent with `StartInterval` 86400 running the same command.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -15,7 +15,9 @@ thing it said.
 - Fast-forward only. A clone that is dirty, detached, without an upstream, off the default branch,
   or diverged is left alone, with one line saying so and naming the fix.
 - At most one run a day, and silent whatever the outcome: the only thing it prints is a problem
-  you have to fix, once per problem. Git and installer output goes to the log.
+  you have to fix, once per problem. A failed fetch retries in an hour instead, so a laptop that
+  was offline this morning still updates later in the day. Git and installer output goes to the
+  log.
 - Never `--force`, so an entry the installers do not own is never replaced.
 - It does replay the installers, so an update can add skills and rules, or drop ones the repo
   removed. Rules are always-on, so that changes how your agent behaves.

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -28,10 +28,11 @@ it changes is the content of skills and rules you already opted into, exactly wh
 
 ## Moving or deleting the clone
 
-Run both installers with `--no-auto-update` before deleting the clone. If it is already gone,
-delete the `hooks.SessionStart` handler whose command contains `/lib/auto-update.sh` from
+Run the installer you use with `--no-auto-update` before deleting the clone. If it is already
+gone, delete the `hooks.SessionStart` handler whose command contains `/lib/auto-update.sh` from
 `~/.claude/settings.json` by hand, or Claude Code reports a failing hook at every startup. A clone
-that moved is fixed by re-running the installers from the new place.
+that moved is fixed by re-running the installers from the new place with `--force`, since without
+it they skip the links still pointing at the old path as entries they do not own.
 
 ## Notes
 

--- a/docs/install-rules.md
+++ b/docs/install-rules.md
@@ -21,11 +21,13 @@ From the repo root:
 ```
 
 It mirrors [the skills install](./install-skills.md): the same two symlink layers
-(`~/.agents/rules` → `~/.claude/rules`), converging re-runs, and `--agents-dir`, `--rules-dir`,
-and `--force` options. On [Windows](./install-skills.md#windows) the rules do not get the junction
-fallback the skills do, since each rule is a single file, so updating means re-running this script
-with `--force`. Rule links left by older `./install.sh` runs stay intact but are updated only by
-this script — run it after `git pull` to keep them in sync.
+(`~/.agents/rules` → `~/.claude/rules`), converging re-runs, the same `--agents-dir`,
+`--rules-dir`, `--force`, `--no-auto-update` and `--auto-update` options, and the same daily
+[self-update hook](./auto-update.md) when Claude Code is detected. On
+[Windows](./install-skills.md#windows) the rules do not get the junction fallback the skills do,
+since each rule is a single file, so updating means re-running this script with `--force`. Rule
+links left by older `./install.sh` runs stay intact but are updated only by this script — run it
+after `git pull` to keep them in sync.
 
 ## Linking rules by hand
 

--- a/docs/install-skills.md
+++ b/docs/install-skills.md
@@ -38,6 +38,8 @@ Options:
 ./install.sh --agents-dir DIR        # custom agent-neutral location (default: ~/.agents)
 ./install.sh --skills-dir DIR        # agent skills dir to wire (e.g. a project's .claude/skills)
 ./install.sh --force                 # overwrite real files/dirs and foreign symlinks
+./install.sh --no-auto-update        # do not register the daily self-update hook (persists)
+./install.sh --auto-update           # register it again after --no-auto-update
 ./install.sh --help
 ```
 
@@ -53,6 +55,20 @@ ln -s ~/.agents/skills/run-nx-checks ~/.claude/skills/
 Start a new session and run `/context` to confirm everything is loaded. Skills apply at the user
 level (all projects); to scope them to one project, wire that project's directory instead, e.g.
 `./install.sh --skills-dir <project>/.claude/skills`.
+
+## Staying up to date
+
+When Claude Code is detected, the install also registers a `SessionStart` hook that fast-forwards
+the clone once a day and re-runs the installers, so you do not have to
+([auto-update.md](./auto-update.md) covers it in full, other agents included). It is registered
+only for Claude's own `~/.claude/skills` (or `~/.claude/rules`), and only for a clone that tracks
+an upstream; anything else — another agent, a project's `.claude/skills` — gets the one-liner to
+wire by hand instead. `--no-auto-update` turns it off and is remembered, `--auto-update` turns it
+back on.
+
+It stays quiet unless the clone is stuck — dirty, detached, without an upstream, off the default
+branch, or diverged — and then says so once, naming the fix. Where entries were installed as
+copies rather than links ([Windows](#windows)), it says to re-run the installer with `--force`.
 
 ## Windows
 

--- a/docs/install-skills.md
+++ b/docs/install-skills.md
@@ -61,10 +61,11 @@ level (all projects); to scope them to one project, wire that project's director
 When Claude Code is detected, the install also registers a `SessionStart` hook that fast-forwards
 the clone once a day and re-runs the installers, so you do not have to
 ([auto-update.md](./auto-update.md) covers it in full, other agents included). It is registered
-only for Claude's own `~/.claude/skills` (or `~/.claude/rules`), and only for a clone that tracks
-an upstream; anything else — another agent, a project's `.claude/skills` — gets the one-liner to
-wire by hand instead. `--no-auto-update` turns it off and is remembered, `--auto-update` turns it
-back on.
+only when installing into Claude's own `~/.claude/skills` (or `~/.claude/rules`), and only for a
+clone that tracks an upstream. That one hook replays every install made from the clone, a
+project's `.claude/skills` included; a clone that only ever installed elsewhere — another agent, a
+project — gets the one-liner to wire by hand instead. `--no-auto-update` turns it off and is
+remembered, `--auto-update` turns it back on.
 
 It stays quiet unless the clone is stuck — dirty, detached, without an upstream, off the default
 branch, or diverged — and then says so once, naming the fix. Where entries were installed as

--- a/install-opinionated-rules.sh
+++ b/install-opinionated-rules.sh
@@ -27,17 +27,26 @@
 #   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
 #   --rules-dir DIR    Agent's rules directory   (default: ~/.claude/rules)
 #   --force            Overwrite real files/dirs and foreign symlinks
+#   --no-auto-update   Do not register the daily self-update hook (persists)
+#   --auto-update      Register it again after --no-auto-update
 #   -h, --help         Show this help
+#
+# When Claude Code is detected, this also registers a hook that fast-forwards
+# this clone once a day and re-runs the installers: docs/auto-update.md.
 
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_DIR_LOGICAL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "${REPO_DIR}/lib/install-utils.sh"
 
 AGENTS_DIR="${HOME}/.agents"
 RULES_DIR="${HOME}/.claude/rules"
 FORCE=0
+AUTO_UPDATE=""
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+TARGET_FLAG=--rules-dir
 
 usage() {
   cat <<'EOF'
@@ -68,7 +77,12 @@ Options:
   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
   --rules-dir DIR    Agent's rules directory   (default: ~/.claude/rules)
   --force            Overwrite real files/dirs and foreign symlinks
+  --no-auto-update   Do not register the daily self-update hook (persists)
+  --auto-update      Register it again after --no-auto-update
   -h, --help         Show this help
+
+When Claude Code is detected, this also registers a hook that fast-forwards
+this clone once a day and re-runs the installers: docs/auto-update.md.
 EOF
   exit "${1:-0}"
 }
@@ -78,6 +92,8 @@ while [ $# -gt 0 ]; do
     --agents-dir) AGENTS_DIR="$2"; shift 2 ;;
     --rules-dir)  RULES_DIR="$2"; shift 2 ;;
     --force) FORCE=1; shift ;;
+    --no-auto-update) AUTO_UPDATE=off; shift ;;
+    --auto-update) AUTO_UPDATE=on; shift ;;
     -h|--help) usage 0 ;;
     *) echo "Unknown option: $1" >&2; usage 1 ;;
   esac
@@ -105,7 +121,8 @@ end_phase
 # name) are skipped too, so no dangling chain links are created.
 echo "Rules -> ${RULES_DIR}"
 mkdir -p "$RULES_DIR"
-if [ "$(cd "$RULES_DIR" && pwd -P)" = "${AGENTS_DIR}/rules" ]; then
+TARGET_DIR="$(cd "$RULES_DIR" && pwd -P)"
+if [ "$TARGET_DIR" = "${AGENTS_DIR}/rules" ]; then
   echo "  ok     (this is the agents dir itself; already populated)"
 else
   prune_dir "$RULES_DIR"
@@ -124,5 +141,6 @@ else
 fi
 
 report_install_health
+finish_auto_update
 
 echo "Done."

--- a/install.sh
+++ b/install.sh
@@ -26,17 +26,26 @@
 #   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
 #   --skills-dir DIR   Agent's skills directory  (default: ~/.claude/skills)
 #   --force            Overwrite real files/dirs and foreign symlinks
+#   --no-auto-update   Do not register the daily self-update hook (persists)
+#   --auto-update      Register it again after --no-auto-update
 #   -h, --help         Show this help
+#
+# When Claude Code is detected, this also registers a hook that fast-forwards
+# this clone once a day and re-runs the installers: docs/auto-update.md.
 
 set -euo pipefail
 
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_DIR_LOGICAL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 . "${REPO_DIR}/lib/install-utils.sh"
 
 AGENTS_DIR="${HOME}/.agents"
 SKILLS_DIR="${HOME}/.claude/skills"
 FORCE=0
+AUTO_UPDATE=""
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+TARGET_FLAG=--skills-dir
 
 usage() {
   cat <<'EOF'
@@ -66,7 +75,12 @@ Options:
   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
   --skills-dir DIR   Agent's skills directory  (default: ~/.claude/skills)
   --force            Overwrite real files/dirs and foreign symlinks
+  --no-auto-update   Do not register the daily self-update hook (persists)
+  --auto-update      Register it again after --no-auto-update
   -h, --help         Show this help
+
+When Claude Code is detected, this also registers a hook that fast-forwards
+this clone once a day and re-runs the installers: docs/auto-update.md.
 EOF
   exit "${1:-0}"
 }
@@ -81,6 +95,8 @@ while [ $# -gt 0 ]; do
       echo "install.sh installs skills only; for the rules run ./install-opinionated-rules.sh instead." >&2
       exit 1 ;;
     --force) FORCE=1; shift ;;
+    --no-auto-update) AUTO_UPDATE=off; shift ;;
+    --auto-update) AUTO_UPDATE=on; shift ;;
     -h|--help) usage 0 ;;
     *) echo "Unknown option: $1" >&2; usage 1 ;;
   esac
@@ -108,7 +124,8 @@ end_phase
 # name) are skipped too, so no dangling chain links are created.
 echo "Skills -> ${SKILLS_DIR}"
 mkdir -p "$SKILLS_DIR"
-if [ "$(cd "$SKILLS_DIR" && pwd -P)" = "${AGENTS_DIR}/skills" ]; then
+TARGET_DIR="$(cd "$SKILLS_DIR" && pwd -P)"
+if [ "$TARGET_DIR" = "${AGENTS_DIR}/skills" ]; then
   echo "  ok     (this is the agents dir itself; already populated)"
 else
   prune_dir "$SKILLS_DIR"
@@ -137,5 +154,6 @@ if [ -d "${AGENTS_DIR}/rules" ]; then
 fi
 
 report_install_health
+finish_auto_update
 
 echo "Done."

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+#
+# Keep this clone current: once a day, fast-forward it to its upstream and
+# replay the installer runs it has recorded, so the installed skills and rules
+# follow the repo.
+#
+# Two output modes, both silent unless the clone is stuck or something failed:
+#
+#   --json   one JSON object on stdout, {} or {"systemMessage": "..."}, for
+#            hooks that parse what their handler prints;
+#   (none)   the message as plain lines, for cron or a hook that logs it.
+#
+# Exits 0 on every path. Git and installer output goes to the log in the state
+# dir, never to stdout. The installers wire this up; the details, and the
+# recipes for agents whose hooks the installers do not know, are in
+# docs/auto-update.md.
+
+set -u
+
+CLONE=""
+STATE=""
+INV=""
+LOG=""
+ERRF=""
+LOCK=""
+STAMP=""
+OFFLINE=""
+REASON=""
+JSON=0
+KEY=""
+MESSAGE=""
+
+DAY=86400
+HOUR=3600
+OFFLINE_STUCK_AFTER=604800
+FETCH_BUDGET=6
+LOCK_STALE_AFTER=60
+
+# Collect what this run has to say. Several outcomes can pile up: the keys
+# decide whether it is worth saying again, the lines are what the user reads.
+add_outcome() {
+  if [ -z "$KEY" ]; then
+    KEY="$1"
+  else
+    KEY="${KEY}|$1"
+  fi
+  if [ -z "$MESSAGE" ]; then
+    MESSAGE="$2"
+  else
+    MESSAGE="${MESSAGE}
+$2"
+  fi
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037'
+}
+
+# Nothing to say, and nothing worth remembering either: a throttled, locked or
+# offline run must leave an earlier reason standing.
+finish_silent() {
+  [ "$JSON" -eq 1 ] && printf '{}\n'
+  exit 0
+}
+
+# Say it once per problem. The reason file holds the keys of the last run that
+# got as far as the fetch, so a problem that is fixed and comes back is worth
+# saying again.
+report_and_exit() {
+  local prev=""
+  [ -f "$REASON" ] && prev="$(cat "$REASON" 2>/dev/null)"
+  printf '%s\n' "$KEY" >"$REASON" 2>/dev/null
+
+  if [ -n "$KEY" ] && [ "$KEY" != "$prev" ]; then
+    if [ "$JSON" -eq 1 ]; then
+      printf '{"systemMessage": "%s"}\n' "$(json_escape "$MESSAGE")"
+    else
+      printf '%s\n' "$MESSAGE"
+    fi
+    exit 0
+  fi
+  finish_silent
+}
+
+# Bounded run: no timeout(1) to lean on, and a fetch that hangs would burn the
+# whole hook budget. stdout to the log, stderr kept apart so we can quote it.
+watchdog() {
+  local secs="$1"
+  shift
+  local pid i=0
+  "$@" >>"$LOG" 2>"$ERRF" &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$i" -ge "$secs" ]; then
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  wait "$pid"
+}
+
+# Nothing here may block on a prompt: no terminal is attached and the agent
+# would sit on it until the hook times out.
+guard_prompts() {
+  export GIT_TERMINAL_PROMPT=0
+  export GIT_ASKPASS=true
+  export GCM_INTERACTIVE=never
+  export SSH_ASKPASS_REQUIRE=never
+
+  local cmd first
+  cmd="${GIT_SSH_COMMAND:-}"
+  [ -n "$cmd" ] || cmd="$(git -C "$CLONE" config core.sshCommand 2>/dev/null)"
+  if [ -z "$cmd" ]; then
+    # GIT_SSH is next in git's precedence, and exporting GIT_SSH_COMMAND would
+    # override it. Leave whatever it points at alone.
+    [ -n "${GIT_SSH:-}" ] && return 0
+    cmd=ssh
+  fi
+  first="$(basename "${cmd%% *}")"
+  case "$first" in
+    ssh|ssh.exe) export GIT_SSH_COMMAND="$cmd -o BatchMode=yes -o ConnectTimeout=5" ;;
+  esac
+  return 0
+}
+
+# git's first stderr line is generic ("merge failed"); the file names follow on
+# the next ones, and they are what tells two conflicts apart.
+stderr_detail() {
+  head -5 "$ERRF" 2>/dev/null | awk '
+    { sub(/^error: /, ""); sub(/^fatal: /, "");
+      gsub(/[ \t]+/, " "); gsub(/^ +| +$/, "");
+      if (length($0)) out = (out == "" ? $0 : out "; " $0) }
+    END { print out }'
+}
+
+# A recorded target the user has deleted stays deleted: the installer would
+# recreate the whole tree in a place they cleared out.
+prune_invocations() {
+  local tmp="${STATE}/invocations.$$" changed=0 line
+  local script agents_dir flag target rec_head copies
+
+  [ -f "$INV" ] || return 0
+  : >"$tmp" 2>/dev/null || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    IFS=$'\t' read -r script agents_dir flag target rec_head copies <<<"$line"
+    if [ ! -d "$target" ] || [ ! -d "$agents_dir" ]; then
+      changed=1
+      continue
+    fi
+    printf '%s\n' "$line" >>"$tmp"
+  done <"$INV"
+
+  if [ "$changed" -eq 1 ]; then
+    mv -f "$tmp" "$INV"
+  else
+    rm -f "$tmp"
+  fi
+  return 0
+}
+
+copies_flag() {
+  local script="$1" target="$2" value
+  value="$(awk -F '\t' -v s="$script" -v t="$target" \
+    '$1 == s && $4 == t { c = $6 } END { print c }' "$INV" 2>/dev/null)"
+  [ -n "$value" ] || value=0
+  printf '%s' "$value"
+}
+
+main() {
+  case "${1:-}" in
+    --json) JSON=1 ;;
+  esac
+
+  CLONE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)" || finish_silent
+
+  local git_dir
+  git_dir="$(git -C "$CLONE" rev-parse --absolute-git-dir 2>/dev/null)" || finish_silent
+  [ -n "$git_dir" ] || finish_silent
+  STATE="${git_dir}/agent-toolkit"
+  mkdir -p "$STATE" 2>/dev/null || finish_silent
+
+  INV="${STATE}/invocations"
+  LOG="${STATE}/log"
+  ERRF="${STATE}/stderr"
+  LOCK="${STATE}/lock"
+  STAMP="${STATE}/stamp"
+  OFFLINE="${STATE}/offline-since"
+  REASON="${STATE}/reason"
+
+  [ -e "${STATE}/opt-out" ] && finish_silent
+
+  local now due
+  now="$(date +%s 2>/dev/null)" || finish_silent
+  due=0
+  [ -f "$STAMP" ] && due="$(cat "$STAMP" 2>/dev/null)"
+  case "$due" in ''|*[!0-9]*) due=0 ;; esac
+  [ "$now" -lt "$due" ] && finish_silent
+  # Marked done before doing anything: a run that dies must not come back every
+  # session.
+  printf '%s\n' "$((now + DAY))" >"$STAMP" 2>/dev/null
+
+  local held
+  if ! mkdir "$LOCK" 2>/dev/null; then
+    held=0
+    [ -f "${LOCK}/ts" ] && held="$(cat "${LOCK}/ts" 2>/dev/null)"
+    case "$held" in ''|*[!0-9]*) held=0 ;; esac
+    [ "$((now - held))" -lt "$LOCK_STALE_AFTER" ] && finish_silent
+    # Whoever held it was killed mid-run, most likely by a hook timeout.
+    rm -rf "$LOCK"
+    mkdir "$LOCK" 2>/dev/null || finish_silent
+  fi
+  trap 'rm -rf "$LOCK"' EXIT TERM INT HUP
+  printf '%s\n' "$now" >"${LOCK}/ts" 2>/dev/null
+
+  : >"$LOG" 2>/dev/null
+  : >"$ERRF" 2>/dev/null
+
+  guard_prompts
+
+  local branch remote
+  branch="$(git -C "$CLONE" symbolic-ref --short -q HEAD 2>/dev/null)" || branch=""
+  remote=""
+  [ -n "$branch" ] && remote="$(git -C "$CLONE" config "branch.${branch}.remote" 2>/dev/null)"
+  [ -n "$remote" ] || remote=origin
+
+  if ! watchdog "$FETCH_BUDGET" git -C "$CLONE" fetch -q; then
+    cat "$ERRF" >>"$LOG" 2>/dev/null
+    printf '%s\n' "$((now + HOUR))" >"$STAMP" 2>/dev/null
+
+    local since url last
+    since=""
+    [ -f "$OFFLINE" ] && since="$(cat "$OFFLINE" 2>/dev/null)"
+    case "$since" in ''|*[!0-9]*) since="" ;; esac
+    if [ -z "$since" ]; then
+      printf '%s\n' "$now" >"$OFFLINE" 2>/dev/null
+      finish_silent
+    fi
+    [ "$((now - since))" -lt "$OFFLINE_STUCK_AFTER" ] && finish_silent
+
+    url="$(git -C "$CLONE" remote get-url "$remote" 2>/dev/null)" || url="$remote"
+    last="$(stderr_detail)"
+    [ -n "$last" ] && last=" ${last}."
+    add_outcome "stuck:offline:${url}" \
+      "agent-toolkit has not reached ${url} for a week, so ${CLONE} is not updating.${last} Check your network, or your access to that remote."
+    report_and_exit
+  fi
+  rm -f "$OFFLINE"
+
+  local dirty upstream default_ref default
+  dirty="$(git -C "$CLONE" status --porcelain --untracked-files=no 2>/dev/null)"
+
+  default_ref="$(git -C "$CLONE" symbolic-ref -q "refs/remotes/${remote}/HEAD" 2>/dev/null)"
+  if [ -z "$default_ref" ] \
+    && git -C "$CLONE" rev-parse --verify -q "refs/remotes/${remote}/main" >/dev/null 2>&1; then
+    default_ref="refs/remotes/${remote}/main"
+  fi
+  default="${default_ref#refs/remotes/${remote}/}"
+  [ -n "$default" ] || default=main
+
+  upstream="$(git -C "$CLONE" rev-parse --symbolic-full-name '@{u}' 2>/dev/null)" || upstream=""
+
+  if [ -n "$dirty" ]; then
+    add_outcome "stuck:dirty:${branch}" \
+      "agent-toolkit is not updating: ${CLONE} has uncommitted changes. Commit or stash them."
+    report_and_exit
+  fi
+  if [ -z "$branch" ]; then
+    add_outcome "stuck:detached:" \
+      "agent-toolkit is not updating: ${CLONE} is on a detached HEAD. Run: git -C '${CLONE}' checkout ${default}"
+    report_and_exit
+  fi
+  if [ -z "$upstream" ]; then
+    add_outcome "stuck:no-upstream:${branch}" \
+      "agent-toolkit is not updating: branch ${branch} in ${CLONE} has no upstream. Run: git -C '${CLONE}' branch --set-upstream-to ${remote}/${default}"
+    report_and_exit
+  fi
+  # Any local branch name is fine as long as it follows the default branch;
+  # a feature branch is someone's own work and not ours to fast-forward.
+  if [ -n "$default_ref" ] && [ "$upstream" != "$default_ref" ]; then
+    add_outcome "stuck:not-default:${branch}" \
+      "agent-toolkit is not updating: ${CLONE} is on ${branch}, which does not track ${remote}/${default}. Run: git -C '${CLONE}' checkout ${default}"
+    report_and_exit
+  fi
+  if ! git -C "$CLONE" merge-base --is-ancestor HEAD "$upstream" >/dev/null 2>&1; then
+    add_outcome "stuck:diverged:${branch}" \
+      "agent-toolkit is not updating: ${CLONE} has commits that are not on ${remote}/${default}. Push them or drop them; git -C '${CLONE}' log @{u}.. lists them."
+    report_and_exit
+  fi
+
+  local head_before head_now rc detail
+  head_before="$(git -C "$CLONE" rev-parse HEAD 2>/dev/null)"
+  if [ "$head_before" != "$(git -C "$CLONE" rev-parse "$upstream" 2>/dev/null)" ]; then
+    git -C "$CLONE" merge --ff-only '@{u}' >>"$LOG" 2>"$ERRF"
+    rc=$?
+    cat "$ERRF" >>"$LOG" 2>/dev/null
+    if [ "$rc" -ne 0 ]; then
+      detail="$(stderr_detail)"
+      add_outcome "error:merge:${branch}:${detail}" \
+        "agent-toolkit could not update ${CLONE}: ${detail}"
+    fi
+  fi
+
+  prune_invocations
+
+  local -a lines=()
+  local -a replayed=()
+  local line script agents_dir flag target rec_head copies cmd
+  if [ -f "$INV" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      [ -n "$line" ] && lines+=("$line")
+    done <"$INV"
+  fi
+
+  head_now="$(git -C "$CLONE" rev-parse HEAD 2>/dev/null)" || head_now=""
+
+  # The list is a snapshot: each installer we run rewrites this file to stamp
+  # its own line.
+  for line in ${lines[@]+"${lines[@]}"}; do
+    IFS=$'\t' read -r script agents_dir flag target rec_head copies <<<"$line"
+    [ -n "$script" ] || continue
+    [ "$rec_head" = "$head_now" ] && continue
+    cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}'"
+    bash "${CLONE}/${script}" --agents-dir "$agents_dir" "$flag" "$target" >>"$LOG" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      add_outcome "error:replay:${script}:${target}" \
+        "agent-toolkit updated ${CLONE} but ${script} failed afterwards, so ${target} is out of date. Run it by hand: ${cmd}"
+      continue
+    fi
+    replayed+=("$line")
+  done
+
+  for line in ${replayed[@]+"${replayed[@]}"}; do
+    IFS=$'\t' read -r script agents_dir flag target rec_head copies <<<"$line"
+    [ "$(copies_flag "$script" "$target")" = "1" ] || continue
+    cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}' --force"
+    add_outcome "copies:${script}:${target}:${head_now}" \
+      "agent-toolkit updated ${CLONE}, but ${target} holds copies rather than links, so it did not follow. Re-run: ${cmd}"
+  done
+
+  report_and_exit
+}
+
+main "$@"

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -219,7 +219,9 @@ main() {
     rm -rf "$LOCK"
     mkdir "$LOCK" 2>/dev/null || finish_silent
   fi
-  trap 'rm -rf "$LOCK"' EXIT TERM INT HUP
+  trap 'rm -rf "$LOCK"' EXIT
+  # exit here, or bash resumes the run once the handler returns
+  trap 'exit 0' TERM INT HUP
   printf '%s\n' "$now" >"${LOCK}/ts" 2>/dev/null
 
   : >"$LOG" 2>/dev/null

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -36,7 +36,10 @@ DAY=86400
 HOUR=3600
 OFFLINE_STUCK_AFTER=604800
 FETCH_BUDGET=6
-LOCK_STALE_AFTER=60
+# The stamp keeps a second run out for an hour at the least, so a lock
+# younger than that belongs to a run that started alongside this one, not to
+# one that died.
+LOCK_STALE_AFTER=3600
 
 # Collect what this run has to say. Several outcomes can pile up: the keys
 # decide whether it is worth saying again, the lines are what the user reads.
@@ -92,15 +95,17 @@ report_and_exit() {
 
 # Bounded run: no timeout(1) to lean on, and a fetch that hangs would burn the
 # whole hook budget. stdout to the log, stderr kept apart so we can quote it.
+# Polled in tenths: a whole second per poll would cost more than the fetch
+# itself on a good day.
 watchdog() {
   local secs="$1"
   shift
-  local pid i=0 rc
+  local pid ticks=0 rc
   "$@" >>"$LOG" 2>"$ERRF" &
   pid=$!
   CHILD="$pid"
   while kill -0 "$pid" 2>/dev/null; do
-    if [ "$i" -ge "$secs" ]; then
+    if [ "$ticks" -ge "$((secs * 10))" ]; then
       # git leaves its transport (ssh, a credential helper) as a direct
       # child; killing git alone orphans it instead of ending the hang.
       pkill -P "$pid" 2>/dev/null
@@ -109,8 +114,8 @@ watchdog() {
       CHILD=""
       return 124
     fi
-    sleep 1
-    i=$((i + 1))
+    sleep 0.1
+    ticks=$((ticks + 1))
   done
   wait "$pid"
   rc=$?
@@ -192,10 +197,16 @@ copies_flag() {
   printf '%s' "$value"
 }
 
+# The lock can change hands mid-run: a run that outlives LOCK_STALE_AFTER is
+# taken over, and a run that lost the start-up race may only find out here.
+still_owner() {
+  [ "$(cat "${LOCK}/owner" 2>/dev/null)" = "$TOKEN" ]
+}
+
 # Only ours to remove: a run that took over after we were declared stale owns
 # the directory now, and deleting it would let a third run in.
 release_lock() {
-  [ "$(cat "${LOCK}/owner" 2>/dev/null)" = "$TOKEN" ] || return 0
+  still_owner || return 0
   rm -rf "$LOCK"
 }
 
@@ -260,7 +271,7 @@ main() {
   # so nothing is renamed, deleted or replaced, and there is no marker a
   # killed run could leave behind to wedge a later takeover.
   [ "$takeover" -eq 1 ] && sleep 1
-  [ "$(cat "${LOCK}/owner" 2>/dev/null)" = "$TOKEN" ] || finish_silent
+  still_owner || finish_silent
   trap release_lock EXIT
   # exit here, or bash resumes the run once the handler returns
   trap 'kill_child; exit 0' TERM INT HUP
@@ -332,7 +343,7 @@ main() {
   # a feature branch is someone's own work and not ours to fast-forward.
   if [ -n "$default_ref" ] && [ "$upstream" != "$default_ref" ]; then
     add_outcome "stuck:not-default:${branch}" \
-      "agent-toolkit is not updating: ${CLONE} is on ${branch}, which does not track ${remote}/${default}. Run: git -C '${CLONE}' checkout ${default}"
+      "agent-toolkit is not updating while ${CLONE} is on ${branch}, which does not track ${remote}/${default}; it resumes after git -C '${CLONE}' checkout ${default}."
     report_and_exit
   fi
   if ! git -C "$CLONE" merge-base --is-ancestor HEAD "$upstream" >/dev/null 2>&1; then
@@ -344,6 +355,7 @@ main() {
   local head_before head_now rc detail
   head_before="$(git -C "$CLONE" rev-parse HEAD 2>/dev/null)"
   if [ "$head_before" != "$(git -C "$CLONE" rev-parse "$upstream" 2>/dev/null)" ]; then
+    still_owner || finish_silent
     git -C "$CLONE" merge --ff-only '@{u}' >>"$LOG" 2>"$ERRF"
     rc=$?
     cat "$ERRF" >>"$LOG" 2>/dev/null
@@ -378,6 +390,7 @@ main() {
       *\'*) cmd="${script} for ${target}; its path has an apostrophe, so the command cannot be safely quoted here" ;;
       *) cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}'" ;;
     esac
+    still_owner || finish_silent
     bash "${CLONE}/${script}" --agents-dir "$agents_dir" "$flag" "$target" >>"$LOG" 2>&1
     rc=$?
     if [ "$rc" -ne 0 ]; then

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -99,6 +99,9 @@ watchdog() {
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$i" -ge "$secs" ]; then
+      # git leaves its transport (ssh, a credential helper) as a direct
+      # child; killing git alone orphans it instead of ending the hang.
+      pkill -P "$pid" 2>/dev/null
       kill "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       return 124
@@ -349,7 +352,10 @@ main() {
     IFS=$'\t' read -r script agents_dir flag target rec_head copies <<<"$line"
     [ -n "$script" ] || continue
     [ "$rec_head" = "$head_now" ] && continue
-    cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}'"
+    case "${CLONE}${agents_dir}${target}" in
+      *\'*) cmd="${script} for ${target}; its path has an apostrophe, so the command cannot be safely quoted here" ;;
+      *) cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}'" ;;
+    esac
     bash "${CLONE}/${script}" --agents-dir "$agents_dir" "$flag" "$target" >>"$LOG" 2>&1
     rc=$?
     if [ "$rc" -ne 0 ]; then
@@ -363,7 +369,10 @@ main() {
   for line in ${replayed[@]+"${replayed[@]}"}; do
     IFS=$'\t' read -r script agents_dir flag target rec_head copies <<<"$line"
     [ "$(copies_flag "$script" "$target")" = "1" ] || continue
-    cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}' --force"
+    case "${CLONE}${agents_dir}${target}" in
+      *\'*) cmd="${script} for ${target} with --force; its path has an apostrophe, so the command cannot be safely quoted here" ;;
+      *) cmd="bash '${CLONE}/${script}' --agents-dir '${agents_dir}' ${flag} '${target}' --force" ;;
+    esac
     add_outcome "copies:${script}:${target}:${head_now}" \
       "agent-toolkit updated ${CLONE}, but ${target} holds copies rather than links, so it did not follow. Re-run: ${cmd}"
   done

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -30,6 +30,7 @@ REASON=""
 JSON=0
 KEY=""
 MESSAGE=""
+CHILD=""
 
 DAY=86400
 HOUR=3600
@@ -94,9 +95,10 @@ report_and_exit() {
 watchdog() {
   local secs="$1"
   shift
-  local pid i=0
+  local pid i=0 rc
   "$@" >>"$LOG" 2>"$ERRF" &
   pid=$!
+  CHILD="$pid"
   while kill -0 "$pid" 2>/dev/null; do
     if [ "$i" -ge "$secs" ]; then
       # git leaves its transport (ssh, a credential helper) as a direct
@@ -104,12 +106,16 @@ watchdog() {
       pkill -P "$pid" 2>/dev/null
       kill "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
+      CHILD=""
       return 124
     fi
     sleep 1
     i=$((i + 1))
   done
   wait "$pid"
+  rc=$?
+  CHILD=""
+  return "$rc"
 }
 
 # Nothing here may block on a prompt: no terminal is attached and the agent
@@ -136,6 +142,12 @@ guard_prompts() {
   return 0
 }
 
+# git remote get-url returns userinfo verbatim; git >= 2.50 already redacts it
+# from its own transport errors, but this is belt and braces for older git.
+redact_userinfo() {
+  sed -E 's#([A-Za-z][A-Za-z0-9+.-]*://)[^/@[:space:]]*@#\1#g'
+}
+
 # git's first stderr line is generic ("merge failed"); the file names follow on
 # the next ones, and they are what tells two conflicts apart.
 stderr_detail() {
@@ -143,7 +155,7 @@ stderr_detail() {
     { sub(/^error: /, ""); sub(/^fatal: /, "");
       gsub(/[ \t]+/, " "); gsub(/^ +| +$/, "");
       if (length($0)) out = (out == "" ? $0 : out "; " $0) }
-    END { print out }'
+    END { print out }' | redact_userinfo
 }
 
 # A recorded target the user has deleted stays deleted: the installer would
@@ -187,6 +199,16 @@ release_lock() {
   rm -rf "$LOCK"
 }
 
+# End the in-flight fetch's whole tree on a signal, or it and its ssh or
+# credential-helper children keep running after this shell exits.
+kill_child() {
+  [ -n "$CHILD" ] || return 0
+  pkill -P "$CHILD" 2>/dev/null
+  kill "$CHILD" 2>/dev/null
+  wait "$CHILD" 2>/dev/null
+  CHILD=""
+}
+
 main() {
   case "${1:-}" in
     --json) JSON=1 ;;
@@ -220,29 +242,28 @@ main() {
   # session.
   printf '%s\n' "$((now + DAY))" >"$STAMP" 2>/dev/null
 
-  local held dead
+  local held takeover=0
   if ! mkdir "$LOCK" 2>/dev/null; then
     held=0
     [ -f "${LOCK}/ts" ] && held="$(cat "${LOCK}/ts" 2>/dev/null)"
     case "$held" in ''|*[!0-9]*) held=0 ;; esac
     [ "$((now - held))" -lt "$LOCK_STALE_AFTER" ] && finish_silent
-    # Whoever held it was killed mid-run, most likely by a hook timeout. Rename
-    # it aside rather than delete it: only one racer can rename a given
-    # directory, so a loser's rm -rf can never take out the winner's new lock.
-    dead="${LOCK}.dead.$$"
-    rm -rf "$dead" 2>/dev/null
-    mv "$LOCK" "$dead" 2>/dev/null
-    rm -rf "$dead"
-    mkdir "$LOCK" 2>/dev/null || finish_silent
+    takeover=1
   fi
   # Stamp it before anything else: a lock with no ts reads as stale, and a run
   # starting right now would take it over.
   printf '%s\n' "$now" >"${LOCK}/ts" 2>/dev/null
   TOKEN="$$:${now}"
   printf '%s\n' "$TOKEN" >"${LOCK}/owner" 2>/dev/null
+  # Whoever's token survives owns the lock; the other abandons the run. Two
+  # runs that judge the same lock stale both write their own token into it,
+  # so nothing is renamed, deleted or replaced, and there is no marker a
+  # killed run could leave behind to wedge a later takeover.
+  [ "$takeover" -eq 1 ] && sleep 1
+  [ "$(cat "${LOCK}/owner" 2>/dev/null)" = "$TOKEN" ] || finish_silent
   trap release_lock EXIT
   # exit here, or bash resumes the run once the handler returns
-  trap 'exit 0' TERM INT HUP
+  trap 'kill_child; exit 0' TERM INT HUP
 
   : >"$LOG" 2>/dev/null
   : >"$ERRF" 2>/dev/null
@@ -270,6 +291,7 @@ main() {
     [ "$((now - since))" -lt "$OFFLINE_STUCK_AFTER" ] && finish_silent
 
     url="$(git -C "$CLONE" remote get-url "$remote" 2>/dev/null)" || url="$remote"
+    url="$(printf '%s\n' "$url" | redact_userinfo)"
     last="$(stderr_detail)"
     [ -n "$last" ] && last=" ${last}."
     add_outcome "stuck:offline:${url}" \

--- a/lib/auto-update.sh
+++ b/lib/auto-update.sh
@@ -23,6 +23,7 @@ INV=""
 LOG=""
 ERRF=""
 LOCK=""
+TOKEN=""
 STAMP=""
 OFFLINE=""
 REASON=""
@@ -176,6 +177,13 @@ copies_flag() {
   printf '%s' "$value"
 }
 
+# Only ours to remove: a run that took over after we were declared stale owns
+# the directory now, and deleting it would let a third run in.
+release_lock() {
+  [ "$(cat "${LOCK}/owner" 2>/dev/null)" = "$TOKEN" ] || return 0
+  rm -rf "$LOCK"
+}
+
 main() {
   case "${1:-}" in
     --json) JSON=1 ;;
@@ -209,20 +217,29 @@ main() {
   # session.
   printf '%s\n' "$((now + DAY))" >"$STAMP" 2>/dev/null
 
-  local held
+  local held dead
   if ! mkdir "$LOCK" 2>/dev/null; then
     held=0
     [ -f "${LOCK}/ts" ] && held="$(cat "${LOCK}/ts" 2>/dev/null)"
     case "$held" in ''|*[!0-9]*) held=0 ;; esac
     [ "$((now - held))" -lt "$LOCK_STALE_AFTER" ] && finish_silent
-    # Whoever held it was killed mid-run, most likely by a hook timeout.
-    rm -rf "$LOCK"
+    # Whoever held it was killed mid-run, most likely by a hook timeout. Rename
+    # it aside rather than delete it: only one racer can rename a given
+    # directory, so a loser's rm -rf can never take out the winner's new lock.
+    dead="${LOCK}.dead.$$"
+    rm -rf "$dead" 2>/dev/null
+    mv "$LOCK" "$dead" 2>/dev/null
+    rm -rf "$dead"
     mkdir "$LOCK" 2>/dev/null || finish_silent
   fi
-  trap 'rm -rf "$LOCK"' EXIT
+  # Stamp it before anything else: a lock with no ts reads as stale, and a run
+  # starting right now would take it over.
+  printf '%s\n' "$now" >"${LOCK}/ts" 2>/dev/null
+  TOKEN="$$:${now}"
+  printf '%s\n' "$TOKEN" >"${LOCK}/owner" 2>/dev/null
+  trap release_lock EXIT
   # exit here, or bash resumes the run once the handler returns
   trap 'exit 0' TERM INT HUP
-  printf '%s\n' "$now" >"${LOCK}/ts" 2>/dev/null
 
   : >"$LOG" 2>/dev/null
   : >"$ERRF" 2>/dev/null
@@ -309,6 +326,7 @@ main() {
       detail="$(stderr_detail)"
       add_outcome "error:merge:${branch}:${detail}" \
         "agent-toolkit could not update ${CLONE}: ${detail}"
+      report_and_exit
     fi
   fi
 

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -256,7 +256,7 @@ follow_links() {
 # structure really changed.
 #
 # Returns: 0 written, 2 already as we want it, 3 file we cannot parse,
-# 4 no usable interpreter.
+# 4 no usable interpreter, 5 we could not write the file.
 settings_merge() {
   local file mode="$2" cmd="$3"
   local tmp rc=4
@@ -266,7 +266,7 @@ settings_merge() {
   file="$(follow_links "$1")"
   tmp="${file}.tmp.$$"
   if [ -f "$file" ]; then
-    cp -p "$file" "$tmp" 2>/dev/null || return 4
+    cp -p "$file" "$tmp" 2>/dev/null || return 5
   fi
 
   # Probe each interpreter before trusting its exit code: the Windows Store
@@ -286,7 +286,7 @@ settings_merge() {
 
   if [ "$rc" -eq 0 ]; then
     if [ -s "$tmp" ]; then
-      mv -f "$tmp" "$file"
+      mv -f "$tmp" "$file" || rc=5
     else
       rc=4
     fi
@@ -316,21 +316,23 @@ except Exception:
 if not isinstance(data, dict):
     sys.exit(3)
 
-hooks = data.get("hooks")
-if hooks is None:
+if "hooks" not in data:
     if mode == "remove":
         sys.exit(2)
     hooks = {}
-elif not isinstance(hooks, dict):
-    sys.exit(3)
+else:
+    hooks = data["hooks"]
+    if not isinstance(hooks, dict):
+        sys.exit(3)
 
-groups = hooks.get("SessionStart")
-if groups is None:
+if "SessionStart" not in hooks:
     if mode == "remove":
         sys.exit(2)
     groups = []
-elif not isinstance(groups, list):
-    sys.exit(3)
+else:
+    groups = hooks["SessionStart"]
+    if not isinstance(groups, list):
+        sys.exit(3)
 for group in groups:
     if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
         sys.exit(3)
@@ -602,6 +604,7 @@ finish_auto_update() {
         0) echo "Auto-update: off (opted out); removed our hook from ${file}. --auto-update turns it back on." ;;
         3) echo "Auto-update: off (opted out), but we cannot work with the JSON in ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
         4) echo "Auto-update: off (opted out), but no working python3, node or jq to edit ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
+        5) echo "Auto-update: off (opted out), but we could not write to ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
         *) echo "Auto-update: off (opted out); no hook of ours in ${file}. --auto-update turns it back on." ;;
       esac
     else
@@ -652,6 +655,8 @@ finish_auto_update() {
        fi ;;
     2) echo "Auto-update: on. Already registered in ${file}." ;;
     3) echo "Auto-update: nothing registered, we cannot work with the JSON in ${file}."
+       auto_update_snippet "$file" "$cmd" ;;
+    5) echo "Auto-update: nothing registered, we could not write to ${file}."
        auto_update_snippet "$file" "$cmd" ;;
     *) echo "Auto-update: nothing registered, no working python3, node or jq to edit ${file}."
        auto_update_snippet "$file" "$cmd" ;;

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -1,7 +1,8 @@
 # Helpers shared by ./install.sh and ./install-opinionated-rules.sh.
 #
-# Sourced, not run. Callers set REPO_DIR, AGENTS_DIR, and FORCE before using
-# the functions below.
+# Sourced, not run. Callers set REPO_DIR (physical), REPO_DIR_LOGICAL (the
+# unresolved pwd, defaults to REPO_DIR), AGENTS_DIR and FORCE before using the
+# functions below.
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   echo "This file provides helpers sourced by the installers; run ./install.sh or ./install-opinionated-rules.sh instead." >&2
@@ -599,7 +600,7 @@ finish_auto_update() {
       settings_merge "$file" remove "$cmd" || rc=$?
       case "$rc" in
         0) echo "Auto-update: off (opted out); removed our hook from ${file}. --auto-update turns it back on." ;;
-        3) echo "Auto-update: off (opted out), but ${file} is not valid JSON. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
+        3) echo "Auto-update: off (opted out), but we cannot work with the JSON in ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
         4) echo "Auto-update: off (opted out), but no working python3, node or jq to edit ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
         *) echo "Auto-update: off (opted out); no hook of ours in ${file}. --auto-update turns it back on." ;;
       esac
@@ -650,7 +651,7 @@ finish_auto_update() {
          echo "Auto-update: on. Registered a daily SessionStart hook in ${file}. --no-auto-update turns it off."
        fi ;;
     2) echo "Auto-update: on. Already registered in ${file}." ;;
-    3) echo "Auto-update: nothing registered, ${file} is not valid JSON."
+    3) echo "Auto-update: nothing registered, we cannot work with the JSON in ${file}."
        auto_update_snippet "$file" "$cmd" ;;
     *) echo "Auto-update: nothing registered, no working python3, node or jq to edit ${file}."
        auto_update_snippet "$file" "$cmd" ;;

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -20,6 +20,7 @@ COPIED_KIND=dir
 NOTHING_INSTALLED=0
 PHASE_DONE=0
 PHASE_SKIPPED=0
+EXISTING_SKIPPED=0
 
 WINDOWS=0
 case "$(uname -s)" in
@@ -66,10 +67,15 @@ note_link_kind() {
 }
 
 # A symlink is "ours" if it points into this repo clone or the agents dir.
+# The logical clone path counts too: an install run through a symlinked path
+# left links pointing that way, and they must be re-pointed, not skipped as
+# someone else's.
 is_ours() {
   local target
   target="$(readlink "$1")" || return 1
-  [[ "$target" == "${REPO_DIR}"/* || "$target" == "${AGENTS_DIR}"/* ]]
+  [[ "$target" == "${REPO_DIR}"/* \
+    || "$target" == "${REPO_DIR_LOGICAL:-$REPO_DIR}"/* \
+    || "$target" == "${AGENTS_DIR}"/* ]]
 }
 
 # Remove broken symlinks we own from directory $1. Broken foreign symlinks
@@ -112,6 +118,9 @@ link_one() {
     else
       echo "  skip   ${name} (already exists; use --force to overwrite)"
       count_skip
+      # Counted apart from count_skip and across phases: record_invocation needs
+      # to know a foreign entry was left alone anywhere in the run.
+      EXISTING_SKIPPED=$((EXISTING_SKIPPED + 1))
       return
     fi
   fi
@@ -166,4 +175,459 @@ report_install_health() {
     echo "  content will not follow this repo. Re-run with --force to replace those entries" >&2
     echo "  (this deletes what is currently there)." >&2
   fi
+}
+
+# ---------------------------------------------------------------------------
+# Auto-update wiring
+#
+# Callers that want it also set SCRIPT_NAME, TARGET_FLAG, TARGET_DIR and
+# AUTO_UPDATE, then call finish_auto_update at the end of a run.
+# ---------------------------------------------------------------------------
+
+AUTO_UPDATE_MARK="/lib/auto-update.sh"
+
+# Where this clone keeps its update state. Inside the git dir so a second clone
+# tracks its own, and nothing lands in the working tree. --absolute-git-dir
+# because hooks run from the session's project dir, and it also resolves the
+# real dir for linked worktrees and submodules.
+toolkit_state_dir() {
+  local git_dir
+  git_dir="$(git -C "$REPO_DIR" rev-parse --absolute-git-dir 2>/dev/null)" || return 1
+  [ -n "$git_dir" ] || return 1
+  mkdir -p "${git_dir}/agent-toolkit" 2>/dev/null || return 1
+  echo "${git_dir}/agent-toolkit"
+}
+
+# One tab-separated line per install, keyed by script + target dir, for the
+# update script to replay:
+#   script  agents_dir  target_flag  target_dir  head  copies
+record_invocation() {
+  local state="$1"
+  local file="${state}/invocations" tmp="${state}/invocations.$$"
+  local head prev copies
+
+  head="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null)" || head=""
+
+  prev=""
+  if [ -f "$file" ]; then
+    prev="$(awk -F '\t' -v s="$SCRIPT_NAME" -v t="$TARGET_DIR" \
+      '$1 == s && $4 == t { c = $6 } END { print c }' "$file" 2>/dev/null)" || prev=""
+  fi
+  [ -n "$prev" ] || prev=0
+
+  # Sticky on purpose: a re-run leaves an existing copy alone as a foreign
+  # entry, so SYMLINKS_REAL stays 1 and would clear a flag that still holds.
+  if [ "$SYMLINKS_REAL" -eq 0 ]; then
+    copies=1
+  elif [ "$EXISTING_SKIPPED" -eq 0 ]; then
+    copies=0
+  else
+    copies="$prev"
+  fi
+
+  : >"$tmp" || return 1
+  if [ -f "$file" ]; then
+    awk -F '\t' -v s="$SCRIPT_NAME" -v t="$TARGET_DIR" \
+      '!($1 == s && $4 == t)' "$file" >>"$tmp" 2>/dev/null || true
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$SCRIPT_NAME" "$AGENTS_DIR" "$TARGET_FLAG" "$TARGET_DIR" "$head" "$copies" >>"$tmp"
+  mv -f "$tmp" "$file"
+}
+
+# Converge our SessionStart handler in a settings file, leaving everything else
+# alone. Whichever of python3, node or jq works first does the edit; the file
+# is rewritten (atomically, since agents watch it) only when the parsed
+# structure really changed.
+#
+# Returns: 0 written, 2 already as we want it, 3 file we cannot parse,
+# 4 no usable interpreter.
+settings_merge() {
+  local file="$1" mode="$2" cmd="$3"
+  local tmp="${file}.tmp.$$" rc=4
+
+  # Probe each interpreter before trusting its exit code: the Windows Store
+  # python3 stub exits non-zero without running anything.
+  if python3 -c 'import json' >/dev/null 2>&1; then
+    settings_merge_python "$file" "$mode" "$cmd" "$tmp"
+    rc=$?
+  fi
+  if [ "$rc" -eq 4 ] && node -e '' >/dev/null 2>&1; then
+    settings_merge_node "$file" "$mode" "$cmd" "$tmp"
+    rc=$?
+  fi
+  if [ "$rc" -eq 4 ] && printf '{}' | jq . >/dev/null 2>&1; then
+    settings_merge_jq "$file" "$mode" "$cmd" "$tmp"
+    rc=$?
+  fi
+
+  if [ "$rc" -eq 0 ]; then
+    if [ -s "$tmp" ]; then
+      mv -f "$tmp" "$file"
+    else
+      rc=4
+    fi
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  return "$rc"
+}
+
+settings_merge_python() {
+  local rc
+  python3 - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" <<'PY'
+import copy, json, sys
+
+path, mode, cmd, tmp, mark = sys.argv[1:6]
+entry = {"type": "command", "command": cmd, "timeout": 10}
+
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except FileNotFoundError:
+    if mode == "remove":
+        sys.exit(2)
+    data = {}
+except Exception:
+    sys.exit(3)
+
+if not isinstance(data, dict):
+    sys.exit(3)
+
+hooks = data.get("hooks")
+if hooks is None:
+    if mode == "remove":
+        sys.exit(2)
+    hooks = {}
+elif not isinstance(hooks, dict):
+    sys.exit(3)
+
+groups = hooks.get("SessionStart")
+if groups is None:
+    if mode == "remove":
+        sys.exit(2)
+    groups = []
+elif not isinstance(groups, list):
+    sys.exit(3)
+for group in groups:
+    if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+        sys.exit(3)
+
+before = copy.deepcopy(data)
+
+
+def ours(handler):
+    return (isinstance(handler, dict)
+            and isinstance(handler.get("command"), str)
+            and mark in handler["command"])
+
+
+kept_one = False
+new_groups = []
+for group in groups:
+    had = any(ours(h) for h in group["hooks"])
+    kept = []
+    for handler in group["hooks"]:
+        if ours(handler):
+            if mode == "register" and not kept_one:
+                kept_one = True
+                kept.append(dict(entry))
+            continue
+        kept.append(handler)
+    group["hooks"] = kept
+    # A group we emptied is ours to clean up; one that came in empty is the
+    # user's business.
+    if had and not kept:
+        continue
+    new_groups.append(group)
+
+if mode == "register":
+    if not kept_one:
+        new_groups.append({"matcher": "startup", "hooks": [dict(entry)]})
+    hooks["SessionStart"] = new_groups
+    data["hooks"] = hooks
+elif new_groups:
+    hooks["SessionStart"] = new_groups
+else:
+    hooks.pop("SessionStart", None)
+
+if data == before:
+    sys.exit(2)
+
+with open(tmp, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2, ensure_ascii=False)
+    fh.write("\n")
+PY
+  rc=$?
+  case "$rc" in 0|2|3) return "$rc" ;; *) return 4 ;; esac
+}
+
+settings_merge_node() {
+  local rc
+  node - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" <<'JS'
+const fs = require("fs");
+const [path, mode, cmd, tmp, mark] = process.argv.slice(2);
+const entry = () => ({ type: "command", command: cmd, timeout: 10 });
+
+let raw = null;
+try {
+  raw = fs.readFileSync(path, "utf8");
+} catch (err) {
+  if (err.code !== "ENOENT") process.exit(3);
+  if (mode === "remove") process.exit(2);
+}
+
+let data = {};
+if (raw !== null) {
+  try {
+    data = JSON.parse(raw);
+  } catch (err) {
+    process.exit(3);
+  }
+}
+
+const isObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+if (!isObject(data)) process.exit(3);
+
+let hooks = data.hooks;
+if (hooks === undefined) {
+  if (mode === "remove") process.exit(2);
+  hooks = {};
+} else if (!isObject(hooks)) {
+  process.exit(3);
+}
+
+let groups = hooks.SessionStart;
+if (groups === undefined) {
+  if (mode === "remove") process.exit(2);
+  groups = [];
+} else if (!Array.isArray(groups)) {
+  process.exit(3);
+}
+for (const group of groups) {
+  if (!isObject(group) || !Array.isArray(group.hooks)) process.exit(3);
+}
+
+const before = JSON.stringify(data);
+const ours = (h) => isObject(h) && typeof h.command === "string" && h.command.includes(mark);
+
+let keptOne = false;
+const newGroups = [];
+for (const group of groups) {
+  const had = group.hooks.some(ours);
+  const kept = [];
+  for (const handler of group.hooks) {
+    if (ours(handler)) {
+      if (mode === "register" && !keptOne) {
+        keptOne = true;
+        kept.push(entry());
+      }
+      continue;
+    }
+    kept.push(handler);
+  }
+  group.hooks = kept;
+  // A group we emptied is ours to clean up; one that came in empty is the
+  // user's business.
+  if (had && kept.length === 0) continue;
+  newGroups.push(group);
+}
+
+if (mode === "register") {
+  if (!keptOne) newGroups.push({ matcher: "startup", hooks: [entry()] });
+  hooks.SessionStart = newGroups;
+  data.hooks = hooks;
+} else if (newGroups.length > 0) {
+  hooks.SessionStart = newGroups;
+} else {
+  delete hooks.SessionStart;
+}
+
+if (JSON.stringify(data) === before) process.exit(2);
+fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+JS
+  rc=$?
+  case "$rc" in 0|2|3) return "$rc" ;; *) return 4 ;; esac
+}
+
+settings_merge_jq() {
+  local file="$1" mode="$2" cmd="$3" tmp="$4"
+  local rc
+
+  if [ ! -f "$file" ]; then
+    [ "$mode" = remove ] && return 2
+  fi
+
+  settings_read_or_empty "$file" | jq -e '
+    if type != "object" then false
+    elif (has("hooks") | not) then true
+    elif (.hooks | type) != "object" then false
+    elif (.hooks | has("SessionStart") | not) then true
+    elif (.hooks.SessionStart | type) != "array" then false
+    else ([ .hooks.SessionStart[]
+            | select((type != "object") or ((.hooks | type) != "array")) ] | length) == 0
+    end' >/dev/null 2>&1 || return 3
+
+  settings_read_or_empty "$file" \
+    | jq --indent 2 --arg cmd "$cmd" --arg mode "$mode" --arg mark "$AUTO_UPDATE_MARK" '
+        def ours: (type == "object")
+          and ((.command | type) == "string")
+          and ((.command | index($mark)) != null);
+        def entry: {type: "command", command: $cmd, timeout: 10};
+
+        . as $in
+        | ((.hooks.SessionStart // []) | to_entries
+           | map(select(.value.hooks | map(ours) | any)) | first | .key?) as $gi
+        | (if $gi == null then null
+           else (.hooks.SessionStart[$gi].hooks | to_entries
+                 | map(select(.value | ours)) | first | .key?) end) as $hi
+        | ([ (.hooks.SessionStart // []) | to_entries[]
+             | .key as $i | .value as $g
+             | ($g.hooks | map(ours) | any) as $had
+             | ($g | .hooks = [ $g.hooks[] | select(ours | not) ]) as $clean
+             # A group we emptied is ours to clean up; one that came in empty
+             # is not ours to touch.
+             | if $mode == "register" and $i == $gi
+               then [ $clean | .hooks = (.hooks[0:$hi] + [entry] + .hooks[$hi:]) ]
+               elif $had and (($clean.hooks | length) == 0) then []
+               else [ $clean ] end ]
+           | add // []) as $new
+        | (if $mode == "remove"
+           then (if ($in | has("hooks") | not) or ($in.hooks | has("SessionStart") | not)
+                 then $in
+                 elif ($new | length) > 0 then ($in | .hooks.SessionStart = $new)
+                 else ($in | del(.hooks.SessionStart)) end)
+           else (if $gi == null
+                 then ($new + [{matcher: "startup", hooks: [entry]}])
+                 else $new end) as $groups
+                | ($in | .hooks = ((.hooks // {}) | .SessionStart = $groups))
+           end)
+        | if . == $in then empty else . end' >"$tmp" 2>/dev/null
+  rc=$?
+
+  [ "$rc" -eq 0 ] || return 4
+  [ -s "$tmp" ] || return 2
+  return 0
+}
+
+settings_read_or_empty() {
+  if [ -f "$1" ]; then
+    cat "$1"
+  else
+    printf '{}'
+  fi
+}
+
+# What to paste when we cannot edit the settings file ourselves.
+auto_update_snippet() {
+  local file="$1" cmd="$2"
+  echo "  Add this to hooks.SessionStart in ${file}:"
+  echo "    {"
+  echo "      \"matcher\": \"startup\","
+  echo "      \"hooks\": [{ \"type\": \"command\", \"command\": \"${cmd}\", \"timeout\": 10 }]"
+  echo "    }"
+  echo "  Details: docs/auto-update.md"
+}
+
+# TARGET_DIR is the agent's own dir, not another agent's and not a project one.
+is_claude_target() {
+  local cfg="$1" kind dir
+  case "$SCRIPT_NAME" in
+    install.sh) kind=skills ;;
+    *) kind=rules ;;
+  esac
+  [ -d "${cfg}/${kind}" ] || return 1
+  dir="$(cd "${cfg}/${kind}" && pwd -P)" || return 1
+  [ "$dir" = "$TARGET_DIR" ]
+}
+
+claude_code_detected() {
+  local cfg="$1"
+  command -v claude >/dev/null 2>&1 && return 0
+  [ -f "${cfg}/settings.json" ] && return 0
+  [ -f "${HOME}/.claude.json" ] && return 0
+  return 1
+}
+
+# Record this run and, when it makes sense, wire the daily update hook.
+# Always exits 0: an installer that cannot set this up still installed.
+finish_auto_update() {
+  local state cfg file cmd rc had_ours
+  local opt_out
+
+  state="$(toolkit_state_dir)" || {
+    echo "Auto-update: off. ${REPO_DIR} is not a git work tree we can read, so it cannot update itself."
+    return 0
+  }
+  record_invocation "$state" || true
+
+  case "${AUTO_UPDATE:-}" in
+    off) : >"${state}/opt-out" ;;
+    on)  rm -f "${state}/opt-out" ;;
+  esac
+
+  cfg="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+  file="${cfg}/settings.json"
+  cmd="bash '${REPO_DIR}/lib/auto-update.sh' --json"
+  opt_out=0
+  [ -e "${state}/opt-out" ] && opt_out=1
+
+  if [ "$opt_out" -eq 1 ]; then
+    if [ -f "$file" ] && is_claude_target "$cfg"; then
+      rc=0
+      settings_merge "$file" remove "$cmd" || rc=$?
+      case "$rc" in
+        0) echo "Auto-update: off (opted out); removed our hook from ${file}. --auto-update turns it back on." ;;
+        3) echo "Auto-update: off (opted out), but ${file} is not valid JSON. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
+        4) echo "Auto-update: off (opted out), but no working python3, node or jq to edit ${file}. Delete the hooks.SessionStart handler whose command contains ${AUTO_UPDATE_MARK} by hand." ;;
+        *) echo "Auto-update: off (opted out); no hook of ours in ${file}. --auto-update turns it back on." ;;
+      esac
+    else
+      echo "Auto-update: off (opted out). --auto-update turns it back on."
+    fi
+    return 0
+  fi
+
+  if ! claude_code_detected "$cfg"; then
+    echo "Auto-update: nothing registered, no Claude Code found here. docs/auto-update.md covers the other agents."
+    return 0
+  fi
+
+  if ! is_claude_target "$cfg"; then
+    echo "Auto-update: nothing registered for ${TARGET_DIR}, which is not Claude Code's own dir. To wire it up, add a SessionStart hook running: ${cmd}"
+    echo "  Details: docs/auto-update.md"
+    return 0
+  fi
+
+  if ! git -C "$REPO_DIR" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+    echo "Auto-update: nothing registered, the branch checked out in ${REPO_DIR} has no upstream to update from. Set one with git -C '${REPO_DIR}' branch --set-upstream-to origin/main, then re-run this script."
+    return 0
+  fi
+
+  case "$REPO_DIR" in
+    *\'*)
+      echo "Auto-update: nothing registered, ${REPO_DIR} contains an apostrophe and we cannot quote it in a hook command. Add it by hand, escaping the path yourself:"
+      auto_update_snippet "$file" "$cmd"
+      return 0 ;;
+  esac
+
+  had_ours=0
+  if [ -f "$file" ] && grep -q "$AUTO_UPDATE_MARK" "$file" 2>/dev/null; then
+    had_ours=1
+  fi
+
+  rc=0
+  settings_merge "$file" register "$cmd" || rc=$?
+  case "$rc" in
+    0) if [ "$had_ours" -eq 1 ]; then
+         echo "Auto-update: on. Updated our daily SessionStart hook in ${file}."
+       else
+         echo "Auto-update: on. Registered a daily SessionStart hook in ${file}. --no-auto-update turns it off."
+       fi ;;
+    2) echo "Auto-update: on. Already registered in ${file}." ;;
+    3) echo "Auto-update: nothing registered, ${file} is not valid JSON."
+       auto_update_snippet "$file" "$cmd" ;;
+    *) echo "Auto-update: nothing registered, no working python3, node or jq to edit ${file}."
+       auto_update_snippet "$file" "$cmd" ;;
+  esac
+  return 0
 }

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -287,6 +287,8 @@ settings_merge() {
   tmp="${file}.tmp.$$"
   if [ -f "$file" ]; then
     cp -p "$file" "$tmp" 2>/dev/null || return 5
+  else
+    : >"$tmp" 2>/dev/null || return 5
   fi
 
   # Probe each interpreter before trusting its exit code: the Windows Store
@@ -562,13 +564,25 @@ settings_read_or_empty() {
   fi
 }
 
+# Local: the two files are never sourced into the same shell, so reusing the
+# name lib/auto-update.sh also uses is safe.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\n'/\\n}"
+  printf '%s' "$s" | tr -d '\000-\010\013\014\016-\037'
+}
+
 # What to paste when we cannot edit the settings file ourselves.
 auto_update_snippet() {
   local file="$1" cmd="$2"
   echo "  Add this to hooks.SessionStart in ${file}:"
   echo "    {"
   echo "      \"matcher\": \"startup\","
-  echo "      \"hooks\": [{ \"type\": \"command\", \"command\": \"${cmd}\", \"timeout\": 10 }]"
+  echo "      \"hooks\": [{ \"type\": \"command\", \"command\": \"$(json_escape "$cmd")\", \"timeout\": 10 }]"
   echo "    }"
   echo "  Details: docs/auto-update.md"
 }
@@ -605,16 +619,28 @@ finish_auto_update() {
   }
   record_invocation "$state" || true
 
+  local marker="${state}/opt-out"
+  opt_out=0
   case "${AUTO_UPDATE:-}" in
-    off) : >"${state}/opt-out" ;;
-    on)  rm -f "${state}/opt-out" ;;
+    off)
+      opt_out=1
+      if ! : >"$marker" 2>/dev/null; then
+        echo "Auto-update: we could not record the opt-out in ${state}, so a later install will turn it back on."
+      fi
+      ;;
+    on)
+      if ! rm -f "$marker" 2>/dev/null; then
+        echo "Auto-update: we could not clear the opt-out in ${state}, so a later install will switch it back off."
+      fi
+      ;;
+    *)
+      [ -e "$marker" ] && opt_out=1
+      ;;
   esac
 
   cfg="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   file="${cfg}/settings.json"
   cmd="bash '${REPO_DIR}/lib/auto-update.sh' --json"
-  opt_out=0
-  [ -e "${state}/opt-out" ] && opt_out=1
 
   if [ "$opt_out" -eq 1 ]; then
     if [ -f "$file" ] && is_claude_target "$cfg"; then

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -16,6 +16,26 @@ resolve_agents_dir() {
   AGENTS_DIR="$(cd "$AGENTS_DIR" && pwd -P)"
 }
 
+# A CLT-less macOS python3 stub pops a blocking "install developer tools"
+# dialog instead of failing fast; bound the probe so a headless run (the
+# auto-update hook, no one present to dismiss it) can't hang on it.
+python3_usable() {
+  local pid i=0
+  python3 -c 'import json' >/dev/null 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$i" -ge 3 ]; then
+      pkill -P "$pid" 2>/dev/null
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 1
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  wait "$pid"
+}
+
 SYMLINKS_REAL=1
 COPIED_KIND=dir
 NOTHING_INSTALLED=0
@@ -271,7 +291,7 @@ settings_merge() {
 
   # Probe each interpreter before trusting its exit code: the Windows Store
   # python3 stub exits non-zero without running anything.
-  if python3 -c 'import json' >/dev/null 2>&1; then
+  if python3_usable; then
     settings_merge_python "$file" "$mode" "$cmd" "$tmp"
     rc=$?
   fi

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -20,18 +20,18 @@ resolve_agents_dir() {
 # dialog instead of failing fast; bound the probe so a headless run (the
 # auto-update hook, no one present to dismiss it) can't hang on it.
 python3_usable() {
-  local pid i=0
+  local pid ticks=0
   python3 -c 'import json' >/dev/null 2>&1 &
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
-    if [ "$i" -ge 3 ]; then
+    if [ "$ticks" -ge 30 ]; then
       pkill -P "$pid" 2>/dev/null
       kill "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       return 1
     fi
-    sleep 1
-    i=$((i + 1))
+    sleep 0.1
+    ticks=$((ticks + 1))
   done
   wait "$pid"
 }
@@ -206,6 +206,9 @@ report_install_health() {
 # ---------------------------------------------------------------------------
 
 AUTO_UPDATE_MARK="/lib/auto-update.sh"
+# Seconds Claude Code gives the hook. The updater bounds its fetch at 6, the
+# rest is the installers replaying, which a slow disk or Windows can stretch.
+AUTO_UPDATE_TIMEOUT=20
 
 # Where this clone keeps its update state. Inside the git dir so a second clone
 # tracks its own, and nothing lands in the working tree. --absolute-git-dir
@@ -273,7 +276,8 @@ follow_links() {
 # Converge our SessionStart handler in a settings file, leaving everything else
 # alone. Whichever of python3, node or jq works first does the edit; the file
 # is rewritten (atomically, since agents watch it) only when the parsed
-# structure really changed.
+# structure really changed. A timeout the user raised on our handler stays
+# raised; anything else about it is ours.
 #
 # Returns: 0 written, 2 already as we want it, 3 file we cannot parse,
 # 4 no usable interpreter, 5 we could not write the file.
@@ -319,14 +323,23 @@ settings_merge() {
 
 settings_merge_python() {
   local rc
-  python3 - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" <<'PY'
+  python3 - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" "$AUTO_UPDATE_TIMEOUT" <<'PY'
 import copy, json, sys
 
-path, mode, cmd, tmp, mark = sys.argv[1:6]
-entry = {"type": "command", "command": cmd, "timeout": 10}
+path, mode, cmd, tmp, mark, timeout = sys.argv[1:7]
+timeout = int(timeout)
+
+
+def entry(old=None):
+    e = {"type": "command", "command": cmd, "timeout": timeout}
+    t = old.get("timeout") if isinstance(old, dict) else None
+    if isinstance(t, (int, float)) and not isinstance(t, bool) and t > timeout:
+        e["timeout"] = t
+    return e
+
 
 try:
-    with open(path, encoding="utf-8") as fh:
+    with open(path, encoding="utf-8-sig") as fh:
         data = json.load(fh)
 except FileNotFoundError:
     if mode == "remove":
@@ -369,15 +382,17 @@ def ours(handler):
 
 
 kept_one = False
+had_any = False
 new_groups = []
 for group in groups:
     had = any(ours(h) for h in group["hooks"])
+    had_any = had_any or had
     kept = []
     for handler in group["hooks"]:
         if ours(handler):
             if mode == "register" and not kept_one:
                 kept_one = True
-                kept.append(dict(entry))
+                kept.append(entry(handler))
             continue
         kept.append(handler)
     group["hooks"] = kept
@@ -389,9 +404,11 @@ for group in groups:
 
 if mode == "register":
     if not kept_one:
-        new_groups.append({"matcher": "startup", "hooks": [dict(entry)]})
+        new_groups.append({"matcher": "startup", "hooks": [entry()]})
     hooks["SessionStart"] = new_groups
     data["hooks"] = hooks
+elif not had_any:
+    sys.exit(2)
 elif new_groups:
     hooks["SessionStart"] = new_groups
 else:
@@ -410,14 +427,19 @@ PY
 
 settings_merge_node() {
   local rc
-  node - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" <<'JS'
+  node - "$1" "$2" "$3" "$4" "$AUTO_UPDATE_MARK" "$AUTO_UPDATE_TIMEOUT" <<'JS'
 const fs = require("fs");
-const [path, mode, cmd, tmp, mark] = process.argv.slice(2);
-const entry = () => ({ type: "command", command: cmd, timeout: 10 });
+const [path, mode, cmd, tmp, mark, timeoutArg] = process.argv.slice(2);
+const timeout = parseInt(timeoutArg, 10);
+const entry = (old) => {
+  const e = { type: "command", command: cmd, timeout };
+  if (old && typeof old.timeout === "number" && old.timeout > timeout) e.timeout = old.timeout;
+  return e;
+};
 
 let raw = null;
 try {
-  raw = fs.readFileSync(path, "utf8");
+  raw = fs.readFileSync(path, "utf8").replace(/^\uFEFF/, "");
 } catch (err) {
   if (err.code !== "ENOENT") process.exit(3);
   if (mode === "remove") process.exit(2);
@@ -458,15 +480,17 @@ const before = JSON.stringify(data);
 const ours = (h) => isObject(h) && typeof h.command === "string" && h.command.includes(mark);
 
 let keptOne = false;
+let hadAny = false;
 const newGroups = [];
 for (const group of groups) {
   const had = group.hooks.some(ours);
+  hadAny = hadAny || had;
   const kept = [];
   for (const handler of group.hooks) {
     if (ours(handler)) {
       if (mode === "register" && !keptOne) {
         keptOne = true;
-        kept.push(entry());
+        kept.push(entry(handler));
       }
       continue;
     }
@@ -483,6 +507,8 @@ if (mode === "register") {
   if (!keptOne) newGroups.push({ matcher: "startup", hooks: [entry()] });
   hooks.SessionStart = newGroups;
   data.hooks = hooks;
+} else if (!hadAny) {
+  process.exit(2);
 } else if (newGroups.length > 0) {
   hooks.SessionStart = newGroups;
 } else {
@@ -515,11 +541,14 @@ settings_merge_jq() {
     end' >/dev/null 2>&1 || return 3
 
   settings_read_or_empty "$file" \
-    | jq --indent 2 --arg cmd "$cmd" --arg mode "$mode" --arg mark "$AUTO_UPDATE_MARK" '
+    | jq --indent 2 --arg cmd "$cmd" --arg mode "$mode" --arg mark "$AUTO_UPDATE_MARK" \
+         --argjson timeout "$AUTO_UPDATE_TIMEOUT" '
         def ours: (type == "object")
           and ((.command | type) == "string")
           and ((.command | index($mark)) != null);
-        def entry: {type: "command", command: $cmd, timeout: 10};
+        def entry($old): {type: "command", command: $cmd,
+          timeout: (if ($old.timeout | type) == "number" and $old.timeout > $timeout
+                    then $old.timeout else $timeout end)};
 
         . as $in
         | ((.hooks.SessionStart // []) | to_entries
@@ -527,6 +556,7 @@ settings_merge_jq() {
         | (if $gi == null then null
            else (.hooks.SessionStart[$gi].hooks | to_entries
                  | map(select(.value | ours)) | first | .key?) end) as $hi
+        | (if $gi == null then null else .hooks.SessionStart[$gi].hooks[$hi] end) as $old
         | ([ (.hooks.SessionStart // []) | to_entries[]
              | .key as $i | .value as $g
              | ($g.hooks | map(ours) | any) as $had
@@ -534,17 +564,16 @@ settings_merge_jq() {
              # A group we emptied is ours to clean up; one that came in empty
              # is not ours to touch.
              | if $mode == "register" and $i == $gi
-               then [ $clean | .hooks = (.hooks[0:$hi] + [entry] + .hooks[$hi:]) ]
+               then [ $clean | .hooks = (.hooks[0:$hi] + [entry($old)] + .hooks[$hi:]) ]
                elif $had and (($clean.hooks | length) == 0) then []
                else [ $clean ] end ]
            | add // []) as $new
         | (if $mode == "remove"
-           then (if ($in | has("hooks") | not) or ($in.hooks | has("SessionStart") | not)
-                 then $in
+           then (if $gi == null then $in
                  elif ($new | length) > 0 then ($in | .hooks.SessionStart = $new)
                  else ($in | del(.hooks.SessionStart)) end)
            else (if $gi == null
-                 then ($new + [{matcher: "startup", hooks: [entry]}])
+                 then ($new + [{matcher: "startup", hooks: [entry(null)]}])
                  else $new end) as $groups
                 | ($in | .hooks = ((.hooks // {}) | .SessionStart = $groups))
            end)
@@ -582,7 +611,7 @@ auto_update_snippet() {
   echo "  Add this to hooks.SessionStart in ${file}:"
   echo "    {"
   echo "      \"matcher\": \"startup\","
-  echo "      \"hooks\": [{ \"type\": \"command\", \"command\": \"$(json_escape "$cmd")\", \"timeout\": 10 }]"
+  echo "      \"hooks\": [{ \"type\": \"command\", \"command\": \"$(json_escape "$cmd")\", \"timeout\": ${AUTO_UPDATE_TIMEOUT} }]"
   echo "    }"
   echo "  Details: docs/auto-update.md"
 }
@@ -610,40 +639,51 @@ claude_code_detected() {
 # Record this run and, when it makes sense, wire the daily update hook.
 # Always exits 0: an installer that cannot set this up still installed.
 finish_auto_update() {
-  local state cfg file cmd rc had_ours
-  local opt_out
-
-  state="$(toolkit_state_dir)" || {
-    echo "Auto-update: off. ${REPO_DIR} is not a git work tree we can read, so it cannot update itself."
-    return 0
-  }
-  record_invocation "$state" || true
-
-  local marker="${state}/opt-out"
-  opt_out=0
-  case "${AUTO_UPDATE:-}" in
-    off)
-      opt_out=1
-      if ! : >"$marker" 2>/dev/null; then
-        echo "Auto-update: we could not record the opt-out in ${state}, so a later install will turn it back on."
-      fi
-      ;;
-    on)
-      if ! rm -f "$marker" 2>/dev/null; then
-        echo "Auto-update: we could not clear the opt-out in ${state}, so a later install will switch it back off."
-      fi
-      ;;
-    *)
-      [ -e "$marker" ] && opt_out=1
-      ;;
-  esac
+  local state cfg file cmd rc had_ours marker
+  local opt_out=0
 
   cfg="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
   file="${cfg}/settings.json"
   cmd="bash '${REPO_DIR}/lib/auto-update.sh' --json"
 
+  had_ours=0
+  if [ -f "$file" ] && grep -q "$AUTO_UPDATE_MARK" "$file" 2>/dev/null; then
+    had_ours=1
+  fi
+
+  if state="$(toolkit_state_dir)"; then
+    record_invocation "$state" || true
+    marker="${state}/opt-out"
+    case "${AUTO_UPDATE:-}" in
+      off)
+        opt_out=1
+        if ! : >"$marker" 2>/dev/null; then
+          echo "Auto-update: we could not record the opt-out in ${state}, so a later install will turn it back on."
+        fi
+        ;;
+      on)
+        if ! rm -f "$marker" 2>/dev/null; then
+          echo "Auto-update: we could not clear the opt-out in ${state}, so a later install will switch it back off."
+        fi
+        ;;
+      *)
+        [ -e "$marker" ] && opt_out=1
+        ;;
+    esac
+  else
+    # Nothing to record and nothing to replay, but an explicit opt-out still
+    # has to get the hook out of the way, or it fails at every session start
+    # once the clone is gone.
+    state=""
+    [ "${AUTO_UPDATE:-}" = off ] && opt_out=1
+  fi
+
   if [ "$opt_out" -eq 1 ]; then
-    if [ -f "$file" ] && is_claude_target "$cfg"; then
+    # A hook naming this clone is ours wherever the install went; on Claude's
+    # own dir any hook of ours goes, since this install took the links over
+    # from whichever clone left it.
+    if [ "$had_ours" -eq 1 ] \
+      && { is_claude_target "$cfg" || grep -qF "$cmd" "$file" 2>/dev/null; }; then
       rc=0
       settings_merge "$file" remove "$cmd" || rc=$?
       case "$rc" in
@@ -656,6 +696,14 @@ finish_auto_update() {
     else
       echo "Auto-update: off (opted out). --auto-update turns it back on."
     fi
+    if [ -z "$state" ]; then
+      echo "Auto-update: the opt-out is not recorded, ${REPO_DIR} is not a git work tree we can read; a later install from a working clone turns it back on."
+    fi
+    return 0
+  fi
+
+  if [ -z "$state" ]; then
+    echo "Auto-update: off. ${REPO_DIR} is not a git work tree we can read, so it cannot update itself."
     return 0
   fi
 
@@ -665,8 +713,13 @@ finish_auto_update() {
   fi
 
   if ! is_claude_target "$cfg"; then
-    echo "Auto-update: nothing registered for ${TARGET_DIR}, which is not Claude Code's own dir. To wire it up, add a SessionStart hook running: ${cmd}"
-    echo "  Details: docs/auto-update.md"
+    # The hook replays every install this clone recorded, this one included.
+    if [ -f "$file" ] && grep -qF "$cmd" "$file" 2>/dev/null; then
+      echo "Auto-update: on. The daily SessionStart hook already in ${file} replays this install too."
+    else
+      echo "Auto-update: nothing registered for ${TARGET_DIR}, which is not Claude Code's own dir. To wire it up, add a SessionStart hook running: ${cmd}"
+      echo "  Details: docs/auto-update.md"
+    fi
     return 0
   fi
 
@@ -685,11 +738,6 @@ finish_auto_update() {
       auto_update_snippet "$file" "$cmd"
       return 0 ;;
   esac
-
-  had_ours=0
-  if [ -f "$file" ] && grep -q "$AUTO_UPDATE_MARK" "$file" 2>/dev/null; then
-    had_ours=1
-  fi
 
   rc=0
   settings_merge "$file" register "$cmd" || rc=$?

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -235,6 +235,20 @@ record_invocation() {
   mv -f "$tmp" "$file"
 }
 
+# Follow a symlink chain by hand: older macOS has no readlink -f.
+follow_links() {
+  local path="$1" target i=0
+  while [ -L "$path" ] && [ "$i" -lt 40 ]; do
+    target="$(readlink "$path")" || break
+    case "$target" in
+      /*) path="$target" ;;
+      *) path="$(dirname "$path")/${target}" ;;
+    esac
+    i=$((i + 1))
+  done
+  printf '%s' "$path"
+}
+
 # Converge our SessionStart handler in a settings file, leaving everything else
 # alone. Whichever of python3, node or jq works first does the edit; the file
 # is rewritten (atomically, since agents watch it) only when the parsed
@@ -243,8 +257,16 @@ record_invocation() {
 # Returns: 0 written, 2 already as we want it, 3 file we cannot parse,
 # 4 no usable interpreter.
 settings_merge() {
-  local file="$1" mode="$2" cmd="$3"
-  local tmp="${file}.tmp.$$" rc=4
+  local file mode="$2" cmd="$3"
+  local tmp rc=4
+
+  # settings.json is often a symlink into a dotfiles repo: edit the target, and
+  # seed the temp file from it so the file's mode survives the rename.
+  file="$(follow_links "$1")"
+  tmp="${file}.tmp.$$"
+  if [ -f "$file" ]; then
+    cp -p "$file" "$tmp" 2>/dev/null || return 4
+  fi
 
   # Probe each interpreter before trusting its exit code: the Windows Store
   # python3 stub exits non-zero without running anything.
@@ -598,6 +620,10 @@ finish_auto_update() {
     return 0
   fi
 
+  if ! git -C "$REPO_DIR" symbolic-ref -q HEAD >/dev/null 2>&1; then
+    echo "Auto-update: nothing registered, ${REPO_DIR} is on a detached HEAD, so there is no branch to update. Check one out with git -C '${REPO_DIR}' checkout main, then re-run this script."
+    return 0
+  fi
   if ! git -C "$REPO_DIR" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
     echo "Auto-update: nothing registered, the branch checked out in ${REPO_DIR} has no upstream to update from. Set one with git -C '${REPO_DIR}' branch --set-upstream-to origin/main, then re-run this script."
     return 0

--- a/test/auto-update/README.md
+++ b/test/auto-update/README.md
@@ -13,6 +13,11 @@ Each case builds its own remote, clone and `HOME` under `runs/<timestamp>/<case>
 there to inspect; `runs/` is gitignored. The clone under test is a snapshot of the working tree, so
 there is no need to commit before running.
 
+The cases that compare the three settings.json engines link the real `node` and `jq` into the
+case's own `bin`. Neither is guaranteed to be on the harness path, so a leg whose binary is missing
+is skipped with a printed `(no jq available, skipping the jq leg)` line — the same run asserts less
+on a machine without them.
+
 It needs write access to the `.git` directories it creates under `runs/` — a sandbox that blocks
 those will fail at the first case.
 

--- a/test/auto-update/README.md
+++ b/test/auto-update/README.md
@@ -18,10 +18,10 @@ case's own `bin`. Neither is guaranteed to be on the harness path, so a leg whos
 is skipped with a printed `(no jq available, skipping the jq leg)` line — the same run asserts less
 on a machine without them.
 
-The harness itself needs a working `python3`: it reads `settings.json` and hook output through it,
-resolved once at startup and called by absolute path so the broken-interpreter shims the cases
-stage cannot reach it. Without a usable one, the run refuses to start rather than producing empty
-comparisons — unlike `node` and `jq` above, which are optional and only skip a leg.
+The harness itself needs a working `python3`: it reads `settings.json` and hook output through
+it, resolved once at startup and called by absolute path so the broken-interpreter shims the
+cases stage cannot reach it. Without a usable one, the run refuses to start rather than producing
+empty comparisons — unlike `node` and `jq` above, which are optional and only skip a leg.
 
 It needs write access to the `.git` directories it creates under `runs/` — a sandbox that blocks
 those will fail at the first case.

--- a/test/auto-update/README.md
+++ b/test/auto-update/README.md
@@ -18,6 +18,11 @@ case's own `bin`. Neither is guaranteed to be on the harness path, so a leg whos
 is skipped with a printed `(no jq available, skipping the jq leg)` line — the same run asserts less
 on a machine without them.
 
+The harness itself needs a working `python3`: it reads `settings.json` and hook output through it,
+resolved once at startup and called by absolute path so the broken-interpreter shims the cases
+stage cannot reach it. Without a usable one, the run refuses to start rather than producing empty
+comparisons — unlike `node` and `jq` above, which are optional and only skip a leg.
+
 It needs write access to the `.git` directories it creates under `runs/` — a sandbox that blocks
 those will fail at the first case.
 

--- a/test/auto-update/README.md
+++ b/test/auto-update/README.md
@@ -1,0 +1,19 @@
+# auto-update harness
+
+Covers [`lib/auto-update.sh`](../../lib/auto-update.sh) and the auto-update wiring in both
+installers: the daily throttle, the lock, the refuse checks, the replay, the feedback, and how the
+installers register or remove the hook in `settings.json`.
+
+```sh
+bash test/auto-update/run.sh            # every case
+bash test/auto-update/run.sh dirty      # named cases only
+```
+
+Each case builds its own remote, clone and `HOME` under `runs/<timestamp>/<case>/` and leaves them
+there to inspect; `runs/` is gitignored. The clone under test is a snapshot of the working tree, so
+there is no need to commit before running.
+
+It needs write access to the `.git` directories it creates under `runs/` — a sandbox that blocks
+those will fail at the first case.
+
+Windows behaviour is not covered.

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -16,12 +16,16 @@ REPO_ROOT="$(cd "${HARNESS_DIR}/../.." && pwd -P)"
 RUNS="${HARNESS_DIR}/runs/$(date +%Y%m%d-%H%M%S)"
 TEMPLATE="${RUNS}/_remote.git"
 
-# /usr/bin holds real git and python3 on macOS, and jq from macOS 15 on, so
-# "no git" and "no interpreter" are staged with failing shims in the case's own
-# bin dir; the installers test what works, not what exists. node and jq usually
-# live elsewhere, so the cases that need them link the real binary in and skip
-# their leg when there is none.
+# Real git, python3, node and jq are resolved before PATH is narrowed to
+# BASE_PATH: git lives in BASE_PATH itself, and python3/node/jq are captured
+# as absolute paths from the caller's PATH. Cases stage "no git" and "no
+# interpreter" as failing shims in the case's own bin dir, because the
+# installers test what works rather than what exists; the harness's own JSON
+# reads go through the resolved $PYTHON so those shims cannot reach them.
+# node and jq are not reliably on BASE_PATH, so a case that needs one links
+# the real binary in and skips its leg when there is none.
 BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+PYTHON="$(command -v python3 2>/dev/null || true)"
 REAL_NODE="$(command -v node 2>/dev/null || true)"
 REAL_JQ="$(command -v jq 2>/dev/null || true)"
 
@@ -43,6 +47,27 @@ die() {
 
 is_repo_root() {
   [ "$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)" = "$1" ]
+}
+
+# A CLT-less macOS python3 stub pops a blocking "install developer tools"
+# dialog instead of failing fast; bound the probe so the harness can't hang on
+# it before the first case even runs.
+python_usable() {
+  [ -n "$PYTHON" ] || return 1
+  local pid i=0
+  "$PYTHON" -c 'import json' >/dev/null 2>&1 &
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$i" -ge 3 ]; then
+      pkill -P "$pid" 2>/dev/null
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 1
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  wait "$pid"
 }
 
 CASE=""
@@ -113,7 +138,7 @@ assert_ran() {
 # --- helpers ---------------------------------------------------------------
 
 json_message() {
-  printf '%s' "$1" | /usr/bin/python3 -c \
+  printf '%s' "$1" | "$PYTHON" -c \
     'import json,sys; print(json.load(sys.stdin).get("systemMessage",""))' 2>/dev/null
 }
 
@@ -126,7 +151,7 @@ hook_count() {
   local file
   file="$(settings_file)"
   [ -f "$file" ] || { echo 0; return 0; }
-  /usr/bin/python3 - "$file" <<'PY' 2>/dev/null
+  "$PYTHON" - "$file" <<'PY' 2>/dev/null
 import json, sys
 try:
     data = json.load(open(sys.argv[1]))
@@ -141,7 +166,7 @@ PY
 
 # Read one value out of the settings file, e.g. hooks.SessionStart.0.matcher.
 settings_get() {
-  /usr/bin/python3 - "$(settings_file)" "$1" <<'PY' 2>/dev/null
+  "$PYTHON" - "$(settings_file)" "$1" <<'PY' 2>/dev/null
 import json, sys
 node = json.load(open(sys.argv[1]))
 for part in sys.argv[2].split("."):
@@ -151,17 +176,28 @@ PY
 }
 
 group_count() {
-  /usr/bin/python3 - "$(settings_file)" <<'PYX' 2>/dev/null
+  "$PYTHON" - "$(settings_file)" <<'PYX' 2>/dev/null
 import json, sys
 print(len(json.load(open(sys.argv[1])).get("hooks", {}).get("SessionStart", [])))
 PYX
 }
 
 top_level_keys() {
-  /usr/bin/python3 - "$(settings_file)" <<'PYX' 2>/dev/null
+  "$PYTHON" - "$(settings_file)" <<'PYX' 2>/dev/null
 import json, sys
 print(json.dumps(sorted(json.load(open(sys.argv[1])).keys())))
 PYX
+}
+
+# The pasteable handler out of the last installer run, as its command string.
+snippet_command() {
+  printf '%s\n' "$OUT" | "$PYTHON" -c '
+import json, sys
+lines = sys.stdin.read().splitlines()
+start = next(i for i, l in enumerate(lines) if l.strip() == "{")
+end = next(i for i in range(start, len(lines)) if lines[i].strip() == "}")
+print(json.loads("\n".join(lines[start:end + 1]))["hooks"][0]["command"])
+'
 }
 
 mtime() {
@@ -569,6 +605,26 @@ case_offline_for_a_week() {
   assert_file_missing "${STATE}/offline-since"
 }
 
+case_offline_url_redacted() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" remote set-url origin https://alice:s3cr3t@no-such-host.invalid/x.git
+  make_due
+  run_hook >/dev/null
+  printf '%s\n' "$(( $(date +%s) - 8 * 86400 ))" >"${STATE}/offline-since"
+  make_due
+  local out msg reason
+  out="$(run_hook)"
+  msg="$(json_message "$out")"
+  reason="$(cat "${STATE}/reason" 2>/dev/null)"
+  assert_contains "message" "$msg" "for a week"
+  assert_contains "message" "$msg" "https://no-such-host.invalid/x.git"
+  assert_not_contains "message" "$msg" "s3cr3t"
+  assert_not_contains "message" "$msg" "alice"
+  assert_not_contains "reason" "$reason" "s3cr3t"
+  assert_not_contains "reason" "$reason" "alice"
+}
+
 case_fetch_hang() {
   detect_claude
   install_skills
@@ -692,6 +748,25 @@ case_lock_not_ours() {
   return 0
 }
 
+case_lock_takeover_loser() {
+  detect_claude
+  install_skills
+  make_due
+  mkdir -p "${STATE}/lock"
+  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  printf 'someone-else\n' >"${STATE}/lock/owner"
+  chmod 400 "${STATE}/lock/owner"
+  printf 'sentinel\n' >"${STATE}/log"
+  local out
+  out="$(run_hook)"
+  chmod 600 "${STATE}/lock/owner"
+  assert_stdout_is '{}' "$out"
+  assert_eq "log untouched" "sentinel" "$(log_text)"
+  assert_eq "lock owner" "someone-else" "$(cat "${STATE}/lock/owner" 2>/dev/null)"
+  [ -d "${STATE}/lock" ] || fail "a lock we did not win was removed"
+  return 0
+}
+
 case_state_in_worktree() {
   detect_claude
   install_skills
@@ -806,7 +881,7 @@ case_moved_clone() {
 case_drifted_hook_entry() {
   detect_claude
   install_skills
-  /usr/bin/python3 - "$(settings_file)" <<'PY'
+  "$PYTHON" - "$(settings_file)" <<'PY'
 import json, sys
 path = sys.argv[1]
 data = json.load(open(path))
@@ -852,6 +927,30 @@ case_opt_out_and_back_in() {
   make_due
   run_hook >/dev/null
   assert_ran
+}
+
+case_marker_write_fails() {
+  detect_claude
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+
+  chmod 500 "$STATE"
+  install_skills --no-auto-update
+  chmod 700 "$STATE"
+  assert_eq "installer exit status" "0" "$INSTALL_RC"
+  assert_contains "installer output" "$OUT" "could not record the opt-out"
+  assert_eq "handler removed" "0" "$(hook_count)"
+  assert_file_missing "${STATE}/opt-out"
+
+  : >"${STATE}/opt-out"
+  chmod 500 "$STATE"
+  install_skills --auto-update
+  chmod 700 "$STATE"
+  assert_eq "installer exit status" "0" "$INSTALL_RC"
+  assert_contains "installer output" "$OUT" "could not clear the opt-out"
+  assert_eq "handler registered" "1" "$(hook_count)"
+  [ -e "${STATE}/opt-out" ] || fail "the marker we could not remove is gone"
+  rm -f "${STATE}/opt-out"
 }
 
 # Every other registering case goes through install.sh, and the rules installer
@@ -946,6 +1045,25 @@ case_apostrophe_in_clone_path() {
   assert_contains "installer output" "$OUT" "apostrophe"
   assert_contains "installer output" "$OUT" "hooks.SessionStart"
   assert_eq "nothing registered" "0" "$(hook_count)"
+}
+
+case_snippet_json_escaped() {
+  detect_claude
+  mkdir -p "${CASE_ROOT}/q\"uote"
+  git clone -q "${CASE_ROOT}/remote.git" "${CASE_ROOT}/q\"uote/clone"
+  CLONE="${CASE_ROOT}/q\"uote/clone"
+  STATE="${CLONE}/.git/agent-toolkit"
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+  assert_eq "registered command" "bash '${CLONE}/lib/auto-update.sh' --json" \
+    "$(settings_get hooks.SessionStart.0.hooks.0.command)"
+
+  broken_shim python3
+  broken_shim node
+  broken_shim jq
+  install_skills
+  assert_contains "installer output" "$OUT" "no working python3, node or jq"
+  assert_eq "snippet command" "bash '${CLONE}/lib/auto-update.sh' --json" "$(snippet_command)"
 }
 
 case_apostrophe_in_replay_advice() {
@@ -1121,6 +1239,21 @@ SH
   assert_contains "installer output" "$OUT" "by hand"
   chmod 700 "${HOME}/.claude"
   assert_eq "handler still there" "1" "$(hook_count)"
+
+  # The previous leg's --no-auto-update left the opt-out marker set (${STATE}
+  # sits outside the dir we just chmod-restricted, so that write succeeded);
+  # clear it, or this plain install takes the opted-out branch instead of
+  # exercising the write failure.
+  rm -f "${STATE}/opt-out"
+  rm -f "$(settings_file)"
+  chmod 500 "${HOME}/.claude"
+  install_skills
+  chmod 700 "${HOME}/.claude"
+  assert_contains "installer output" "$OUT" "could not write to"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_not_contains "installer output" "$OUT" "no working python3"
+  assert_not_contains "installer output" "$OUT" "Registered a daily"
+  assert_file_missing "$(settings_file)"
 }
 
 # Both shapes, through whichever engine is live: a key that is present and null
@@ -1271,6 +1404,31 @@ case_term_releases_the_lock() {
   return 0
 }
 
+case_term_ends_the_fetch() {
+  detect_claude
+  install_skills
+  write_shim ssh "$(printf '#!/bin/sh\necho $$ > %s\nexec sleep 30' "${CASE_ROOT}/ssh.pid")"
+  git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
+  make_due
+  local pid child rc
+  bash "${CLONE}/lib/auto-update.sh" --json >/dev/null &
+  pid=$!
+  sleep 2
+  child="$(cat "${CASE_ROOT}/ssh.pid" 2>/dev/null)"
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid"
+  rc=$?
+  assert_eq "exit status after TERM" "0" "$rc"
+  [ -d "${STATE}/lock" ] && fail "the lock should be released on TERM"
+  if [ -z "$child" ]; then
+    fail "the ssh shim never recorded a pid"
+  elif kill -0 "$child" 2>/dev/null; then
+    fail "the stalled transport survived the TERM"
+    kill -9 "$child" 2>/dev/null
+  fi
+  return 0
+}
+
 case_plain_output_mode() {
   detect_claude
   install_skills
@@ -1306,13 +1464,16 @@ detached
 no_upstream
 offline
 offline_for_a_week
+offline_url_redacted
 fetch_hang
 ssh_guard
 throttled
 lock_held
 stale_lock
 lock_not_ours
+lock_takeover_loser
 term_releases_the_lock
+term_ends_the_fetch
 state_in_worktree
 state_in_submodule
 copies_recorded
@@ -1321,6 +1482,7 @@ feedback_is_json_escaped
 moved_clone
 drifted_hook_entry
 opt_out_and_back_in
+marker_write_fails
 rules_installer_registers
 claude_not_detected
 git_unusable
@@ -1329,6 +1491,7 @@ non_claude_skills_dir
 no_upstream_at_install
 detached_at_install
 apostrophe_in_clone_path
+snippet_json_escaped
 apostrophe_in_replay_advice
 settings_created
 settings_keeps_foreign_hooks
@@ -1368,6 +1531,8 @@ for name in $WANTED; do
     *) die "unknown case: ${name}" ;;
   esac
 done
+
+python_usable || die "no usable python3 found; the harness reads settings.json and hook output with it"
 
 mkdir -p "$RUNS"
 export HOME="${RUNS}/_home"

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -803,6 +803,20 @@ case_opt_out_and_back_in() {
   assert_ran
 }
 
+# Every other registering case goes through install.sh, and the rules installer
+# has its own target check.
+case_rules_installer_registers() {
+  detect_claude
+  install_rules
+  assert_contains "installer output" "$OUT" "Auto-update: on"
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_contains "hook command" "$(settings_get hooks.SessionStart.0)" "${CLONE}/lib/auto-update.sh"
+  local target
+  target="$(cd "${HOME}/.claude/rules" && pwd -P)"
+  assert_eq "recorded flag" "--rules-dir" \
+    "$(record_field install-opinionated-rules.sh "$target" 3)"
+}
+
 case_claude_not_detected() {
   install_skills
   assert_contains "installer output" "$OUT" "no Claude Code found"
@@ -961,11 +975,15 @@ case_settings_engines_agree() {
   if [ -n "$REAL_NODE" ]; then
     ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
     broken_shim python3
+    # jq has to go too, or a dead node just falls through to it and every
+    # assertion below still passes.
+    broken_shim jq
     write_hard_settings
     install_skills --auto-update
     assert_eq "node register" "$registered" "$(cat "$(settings_file)")"
     install_skills --no-auto-update
     assert_eq "node remove" "$removed" "$(cat "$(settings_file)")"
+    rm -f "${CASE_ROOT}/bin/jq"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
@@ -996,9 +1014,10 @@ case_interpreter_fallthrough() {
   broken_shim python3
   if [ -n "$REAL_NODE" ]; then
     ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim jq
     install_skills
     assert_eq "node did the merge" "1" "$(hook_count)"
-    rm -f "$(settings_file)"
+    rm -f "$(settings_file)" "${CASE_ROOT}/bin/jq"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
@@ -1015,11 +1034,13 @@ case_remove_interpreter_fallthrough() {
   broken_shim python3
   if [ -n "$REAL_NODE" ]; then
     ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim jq
     install_skills
     assert_eq "node registered" "1" "$(hook_count)"
     install_skills --no-auto-update
     assert_eq "node removed" "0" "$(hook_count)"
     assert_eq "node dropped the group" "0" "$(group_count)"
+    rm -f "${CASE_ROOT}/bin/jq"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
@@ -1137,6 +1158,7 @@ feedback_is_json_escaped
 moved_clone
 drifted_hook_entry
 opt_out_and_back_in
+rules_installer_registers
 claude_not_detected
 git_unusable
 symlinked_clone_path

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -16,11 +16,14 @@ REPO_ROOT="$(cd "${HARNESS_DIR}/../.." && pwd -P)"
 RUNS="${HARNESS_DIR}/runs/$(date +%Y%m%d-%H%M%S)"
 TEMPLATE="${RUNS}/_remote.git"
 
-# /usr/bin holds real git, python3 and jq on macOS, so "no git" and "no
-# interpreter" are staged with failing shims in the case's own bin dir; the
-# installers test what works, not what exists.
+# /usr/bin holds real git and python3 on macOS, and jq from macOS 15 on, so
+# "no git" and "no interpreter" are staged with failing shims in the case's own
+# bin dir; the installers test what works, not what exists. node and jq usually
+# live elsewhere, so the cases that need them link the real binary in and skip
+# their leg when there is none.
 BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 REAL_NODE="$(command -v node 2>/dev/null || true)"
+REAL_JQ="$(command -v jq 2>/dev/null || true)"
 
 # Belt and braces: without a ceiling, a git command in a directory that failed
 # to become a repo walks up and hits the developer's own checkout.
@@ -418,6 +421,25 @@ case_untracked_conflict() {
   assert_message_contains "$out" "could not update"
 }
 
+# A failed fast-forward means nothing moved, so the recorded installers must not
+# run: every message they produce claims the clone was updated.
+case_conflict_skips_replay() {
+  detect_claude
+  install_skills
+  push_skill zz-harness-skill
+  git -C "$CLONE" pull -q --ff-only
+  push_file conflict.txt "from upstream"
+  printf 'mine\n' >"${CLONE}/conflict.txt"
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "could not update"
+  assert_message_contains "$out" "conflict.txt"
+  assert_not_contains "message" "$(json_message "$out")" "agent-toolkit updated"
+  assert_file_missing "${HOME}/.claude/skills/zz-harness-skill"
+  assert_not_contains "log" "$(log_text)" "Skills ->"
+}
+
 case_replay_failure() {
   detect_claude
   install_skills
@@ -638,6 +660,35 @@ case_stale_lock() {
   assert_stdout_is '{}' "$out"
   assert_not_contains "log" "$(log_text)" "sentinel"
   [ -d "${STATE}/lock" ] && fail "the lock should be released at exit"
+  return 0
+}
+
+# The trap must recognise its own lock: a successor that took over after we were
+# declared stale owns the directory, and removing it would let a third run in.
+case_lock_not_ours() {
+  detect_claude
+  install_skills
+  write_shim ssh $'#!/bin/sh\nsleep 30'
+  git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
+  make_due
+  local pid mine
+  bash "${CLONE}/lib/auto-update.sh" --json >/dev/null &
+  pid=$!
+  sleep 2
+  mine="$(cat "${STATE}/lock/owner" 2>/dev/null)"
+  [ -n "$mine" ] || fail "the run recorded no owner token"
+  printf 'someone-else\n' >"${STATE}/lock/owner"
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  [ -d "${STATE}/lock" ] || fail "a lock we do not own was removed"
+  assert_eq "lock owner" "someone-else" "$(cat "${STATE}/lock/owner" 2>/dev/null)"
+
+  # Takeover goes by the timestamp, not the token: someone else's stale lock is
+  # still ours to claim.
+  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  make_due
+  run_hook >/dev/null
+  assert_file_missing "${STATE}/lock"
   return 0
 }
 
@@ -983,7 +1034,6 @@ case_settings_engines_agree() {
     assert_eq "node register" "$registered" "$(cat "$(settings_file)")"
     install_skills --no-auto-update
     assert_eq "node remove" "$removed" "$(cat "$(settings_file)")"
-    rm -f "${CASE_ROOT}/bin/jq"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
@@ -992,11 +1042,16 @@ case_settings_engines_agree() {
     broken_shim node
   fi
 
-  write_hard_settings
-  install_skills --auto-update
-  assert_eq "jq register" "$registered" "$(cat "$(settings_file)")"
-  install_skills --no-auto-update
-  assert_eq "jq remove" "$removed" "$(cat "$(settings_file)")"
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    write_hard_settings
+    install_skills --auto-update
+    assert_eq "jq register" "$registered" "$(cat "$(settings_file)")"
+    install_skills --no-auto-update
+    assert_eq "jq remove" "$removed" "$(cat "$(settings_file)")"
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
 }
 
 case_settings_unparsable() {
@@ -1009,6 +1064,85 @@ case_settings_unparsable() {
   assert_eq "file untouched" '{ nope' "$(cat "$(settings_file)")"
 }
 
+case_settings_write_fails() {
+  detect_claude
+  local body foreign
+  body="$(cat <<'SH'
+#!/bin/sh
+# Only the settings write must fail; the invocations record needs a real mv.
+for last; do :; done
+case "$last" in
+  */settings.json) exit 1 ;;
+esac
+exec /bin/mv "$@"
+SH
+)"
+  write_shim mv "$body"
+  install_skills
+  assert_contains "installer output" "$OUT" "could not write to"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_not_contains "installer output" "$OUT" "Registered a daily"
+  assert_file_missing "$(settings_file)"
+  rm -f "${CASE_ROOT}/bin/mv"
+
+  foreign='{ "model": "opus" }'
+  printf '%s\n' "$foreign" >"$(settings_file)"
+  chmod 500 "${HOME}/.claude"
+  install_skills
+  assert_contains "installer output" "$OUT" "could not write to"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_not_contains "installer output" "$OUT" "Registered a daily"
+  chmod 700 "${HOME}/.claude"
+  assert_eq "file untouched" "$foreign" "$(cat "$(settings_file)")"
+
+  install_skills
+  assert_eq "one handler" "1" "$(hook_count)"
+  chmod 500 "${HOME}/.claude"
+  install_skills --no-auto-update
+  assert_contains "installer output" "$OUT" "could not write to"
+  assert_contains "installer output" "$OUT" "by hand"
+  chmod 700 "${HOME}/.claude"
+  assert_eq "handler still there" "1" "$(hook_count)"
+}
+
+# Both shapes, through whichever engine is live: a key that is present and null
+# is not an absent key, and overwriting it would throw away what the user wrote.
+assert_null_hooks_refused() {
+  local doc
+  for doc in '{"hooks": null}' '{"hooks": {"SessionStart": null}}'; do
+    printf '%s\n' "$doc" >"$(settings_file)"
+    install_skills
+    assert_contains "$1 refused it" "$OUT" "cannot work with the JSON in"
+    assert_eq "$1 left the file alone" "$doc" "$(cat "$(settings_file)")"
+  done
+}
+
+case_settings_null_hooks() {
+  detect_claude
+  mkdir -p "${HOME}/.claude"
+  assert_null_hooks_refused python3
+
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim python3
+    broken_shim jq
+    assert_null_hooks_refused node
+    broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
+  else
+    echo "    (no node available, skipping the node leg)"
+    broken_shim python3
+    broken_shim node
+  fi
+
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    assert_null_hooks_refused jq
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
+}
+
 case_interpreter_fallthrough() {
   detect_claude
   broken_shim python3
@@ -1017,14 +1151,19 @@ case_interpreter_fallthrough() {
     broken_shim jq
     install_skills
     assert_eq "node did the merge" "1" "$(hook_count)"
-    rm -f "$(settings_file)" "${CASE_ROOT}/bin/jq"
+    rm -f "$(settings_file)"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
     echo "    (no node available, skipping the node leg)"
   fi
-  install_skills
-  assert_eq "jq did the merge" "1" "$(hook_count)"
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    install_skills
+    assert_eq "jq did the merge" "1" "$(hook_count)"
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
 }
 
 # Every other remove test runs under python3. node and jq have to drop the
@@ -1040,17 +1179,21 @@ case_remove_interpreter_fallthrough() {
     install_skills --no-auto-update
     assert_eq "node removed" "0" "$(hook_count)"
     assert_eq "node dropped the group" "0" "$(group_count)"
-    rm -f "${CASE_ROOT}/bin/jq"
     broken_shim node
     "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
     echo "    (no node available, skipping the node leg)"
   fi
-  install_skills --auto-update
-  assert_eq "jq registered" "1" "$(hook_count)"
-  install_skills --no-auto-update
-  assert_eq "jq removed" "0" "$(hook_count)"
-  assert_eq "jq dropped the group" "0" "$(group_count)"
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    install_skills --auto-update
+    assert_eq "jq registered" "1" "$(hook_count)"
+    install_skills --no-auto-update
+    assert_eq "jq removed" "0" "$(hook_count)"
+    assert_eq "jq dropped the group" "0" "$(group_count)"
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
 }
 
 case_no_interpreter() {
@@ -1136,6 +1279,7 @@ target_removed
 dirty
 second_error_reported
 untracked_conflict
+conflict_skips_replay
 replay_failure
 diverged
 non_default_branch
@@ -1149,6 +1293,7 @@ ssh_guard
 throttled
 lock_held
 stale_lock
+lock_not_ours
 term_releases_the_lock
 state_in_worktree
 state_in_submodule
@@ -1170,6 +1315,8 @@ settings_created
 settings_keeps_foreign_hooks
 settings_engines_agree
 settings_unparsable
+settings_write_fails
+settings_null_hooks
 interpreter_fallthrough
 remove_interpreter_fallthrough
 no_interpreter
@@ -1194,13 +1341,21 @@ build_template() {
   git clone -q --bare "$src" "$TEMPLATE" || die "could not build the template remote"
 }
 
+WANTED="$*"
+KNOWN=" $(printf '%s' "$CASES" | tr '\n' ' ') "
+for name in $WANTED; do
+  case "$KNOWN" in
+    *" ${name} "*) ;;
+    *) die "unknown case: ${name}" ;;
+  esac
+done
+
 mkdir -p "$RUNS"
 export HOME="${RUNS}/_home"
 mkdir -p "$HOME"
 export PATH="$BASE_PATH"
 build_template
 
-WANTED="$*"
 for name in $CASES; do
   if [ -n "$WANTED" ]; then
     case " $WANTED " in *" $name "*) ;; *) continue ;; esac

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -156,6 +156,10 @@ mtime() {
   stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
 }
 
+mode() {
+  stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1" 2>/dev/null
+}
+
 new_case() {
   CASE="$1"
   CASE_FAILS=0
@@ -728,6 +732,10 @@ case_moved_clone() {
   assert_eq "one handler" "1" "$(hook_count)"
   assert_contains "hook command" "$(settings_get hooks.SessionStart.0.hooks.0.command)" \
     "${CASE_ROOT}/clone2/lib/auto-update.sh"
+  # links still target the old path and count as foreign, so only --force re-points them
+  assert_link_target "${HOME}/.agents/skills/handover" "${CASE_ROOT}/clone/skills/handover"
+  install_skills --force
+  assert_link_target "${HOME}/.agents/skills/handover" "${CLONE}/skills/handover"
 }
 
 case_drifted_hook_entry() {
@@ -836,6 +844,15 @@ case_no_upstream_at_install() {
   assert_eq "nothing registered" "0" "$(hook_count)"
 }
 
+case_detached_at_install() {
+  detect_claude
+  git -C "$CLONE" checkout -q --detach HEAD
+  install_skills
+  assert_contains "installer output" "$OUT" "detached HEAD"
+  assert_not_contains "installer output" "$OUT" "--set-upstream-to"
+  assert_eq "nothing registered" "0" "$(hook_count)"
+}
+
 case_apostrophe_in_clone_path() {
   detect_claude
   mkdir -p "${CASE_ROOT}/it's"
@@ -929,6 +946,41 @@ case_settings_written_only_on_change() {
   assert_eq "settings mtime" "$before" "$(mtime "$(settings_file)")"
 }
 
+case_settings_symlinked() {
+  detect_claude
+  mkdir -p "${HOME}/dotfiles" "${HOME}/.claude"
+  printf '{ "model": "opus" }\n' >"${HOME}/dotfiles/settings.json"
+  chmod 600 "${HOME}/dotfiles/settings.json"
+  ln -s ../dotfiles/settings.json "$(settings_file)"
+  install_skills
+  [ -L "$(settings_file)" ] || fail "settings.json is no longer a symlink"
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_contains "written through the link" "$(cat "${HOME}/dotfiles/settings.json")" \
+    "lib/auto-update.sh"
+  assert_eq "mode kept" "600" "$(mode "${HOME}/dotfiles/settings.json")"
+}
+
+case_term_releases_the_lock() {
+  detect_claude
+  install_skills
+  write_shim ssh $'#!/bin/sh\nsleep 30'
+  git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
+  make_due
+  local pid started ended
+  started="$(date +%s)"
+  bash "${CLONE}/lib/auto-update.sh" --json >/dev/null &
+  pid=$!
+  sleep 2
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  ended="$(date +%s)"
+  [ -d "${STATE}/lock" ] && fail "the lock should be released on TERM"
+  if [ "$((ended - started))" -gt 5 ]; then
+    fail "TERM should end the run, it took $((ended - started))s"
+  fi
+  return 0
+}
+
 case_plain_output_mode() {
   detect_claude
   install_skills
@@ -968,6 +1020,7 @@ ssh_guard
 throttled
 lock_held
 stale_lock
+term_releases_the_lock
 state_in_worktree
 state_in_submodule
 copies_recorded
@@ -981,6 +1034,7 @@ git_unusable
 symlinked_clone_path
 non_claude_skills_dir
 no_upstream_at_install
+detached_at_install
 apostrophe_in_clone_path
 settings_created
 settings_keeps_foreign_hooks
@@ -988,6 +1042,7 @@ settings_unparsable
 interpreter_fallthrough
 no_interpreter
 settings_written_only_on_change
+settings_symlinked
 plain_output_mode
 "
 

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -1,0 +1,1023 @@
+#!/usr/bin/env bash
+#
+# Harness for lib/auto-update.sh and the auto-update wiring in the installers.
+#
+# Usage:
+#   bash test/auto-update/run.sh [case ...]
+#
+# Every case builds its own remote, clone and HOME under
+# test/auto-update/runs/<timestamp>/<case>/ and leaves them there to inspect.
+# Exits non-zero if any case failed.
+
+set -u
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${HARNESS_DIR}/../.." && pwd -P)"
+RUNS="${HARNESS_DIR}/runs/$(date +%Y%m%d-%H%M%S)"
+TEMPLATE="${RUNS}/_remote.git"
+
+# /usr/bin holds real git, python3 and jq on macOS, so "no git" and "no
+# interpreter" are staged with failing shims in the case's own bin dir; the
+# installers test what works, not what exists.
+BASE_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+REAL_NODE="$(command -v node 2>/dev/null || true)"
+
+# Belt and braces: without a ceiling, a git command in a directory that failed
+# to become a repo walks up and hits the developer's own checkout.
+export GIT_CEILING_DIRECTORIES="$RUNS"
+export GIT_AUTHOR_NAME="Toolkit Harness"
+export GIT_AUTHOR_EMAIL="harness@example.invalid"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+unset CLAUDE_CONFIG_DIR
+unset GIT_SSH_COMMAND
+unset GIT_SSH
+
+die() {
+  echo "harness: $*" >&2
+  exit 2
+}
+
+is_repo_root() {
+  [ "$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)" = "$1" ]
+}
+
+CASE=""
+CASE_ROOT=""
+CLONE=""
+STATE=""
+PUSHER=""
+OUT=""
+CASE_FAILS=0
+TOTAL_FAILS=0
+RAN=0
+
+# --- assertions ------------------------------------------------------------
+
+fail() {
+  echo "    FAIL: $*"
+  CASE_FAILS=$((CASE_FAILS + 1))
+}
+
+assert_eq() {
+  [ "$2" = "$3" ] && return 0
+  fail "$1: expected [$2], got [$3]"
+}
+
+assert_contains() {
+  case "$2" in *"$3"*) return 0 ;; esac
+  fail "$1: [$2] does not contain [$3]"
+}
+
+assert_not_contains() {
+  case "$2" in *"$3"*) fail "$1: [$2] should not contain [$3]" ;; esac
+  return 0
+}
+
+assert_stdout_is() {
+  assert_eq "stdout" "$1" "$2"
+}
+
+assert_message_contains() {
+  local msg
+  msg="$(json_message "$1")"
+  assert_contains "message" "$msg" "$2"
+}
+
+assert_link() {
+  [ -L "$1" ] || fail "expected a symlink at $1"
+}
+
+assert_link_target() {
+  local got
+  got="$(readlink "$1" 2>/dev/null)"
+  assert_eq "link target of $1" "$2" "$got"
+}
+
+assert_file_missing() {
+  if [ -e "$1" ]; then fail "expected $1 to be gone"; fi
+}
+
+# --- helpers ---------------------------------------------------------------
+
+json_message() {
+  printf '%s' "$1" | /usr/bin/python3 -c \
+    'import json,sys; print(json.load(sys.stdin).get("systemMessage",""))' 2>/dev/null
+}
+
+settings_file() {
+  printf '%s' "${HOME}/.claude/settings.json"
+}
+
+# Number of handlers of ours anywhere in hooks.SessionStart.
+hook_count() {
+  local file
+  file="$(settings_file)"
+  [ -f "$file" ] || { echo 0; return 0; }
+  /usr/bin/python3 - "$file" <<'PY' 2>/dev/null
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    print(-1)
+    sys.exit(0)
+groups = data.get("hooks", {}).get("SessionStart", [])
+print(sum(1 for g in groups for h in g.get("hooks", [])
+          if "/lib/auto-update.sh" in (h.get("command") or "")))
+PY
+}
+
+# Read one value out of the settings file, e.g. hooks.SessionStart.0.matcher.
+settings_get() {
+  /usr/bin/python3 - "$(settings_file)" "$1" <<'PY' 2>/dev/null
+import json, sys
+node = json.load(open(sys.argv[1]))
+for part in sys.argv[2].split("."):
+    node = node[int(part)] if isinstance(node, list) else node[part]
+print(node if not isinstance(node, (dict, list)) else json.dumps(node))
+PY
+}
+
+group_count() {
+  /usr/bin/python3 - "$(settings_file)" <<'PYX' 2>/dev/null
+import json, sys
+print(len(json.load(open(sys.argv[1])).get("hooks", {}).get("SessionStart", [])))
+PYX
+}
+
+top_level_keys() {
+  /usr/bin/python3 - "$(settings_file)" <<'PYX' 2>/dev/null
+import json, sys
+print(json.dumps(sorted(json.load(open(sys.argv[1])).keys())))
+PYX
+}
+
+mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+new_case() {
+  CASE="$1"
+  CASE_FAILS=0
+  CASE_ROOT="${RUNS}/${CASE}"
+  PUSHER=""
+  mkdir -p "${CASE_ROOT}/home" "${CASE_ROOT}/bin"
+  cp -R "$TEMPLATE" "${CASE_ROOT}/remote.git"
+  export HOME="${CASE_ROOT}/home"
+  export PATH="${CASE_ROOT}/bin:${BASE_PATH}"
+  git clone -q "${CASE_ROOT}/remote.git" "${CASE_ROOT}/clone" \
+    || die "could not clone the case repo for ${CASE}"
+  CLONE="${CASE_ROOT}/clone"
+  STATE="${CLONE}/.git/agent-toolkit"
+  echo "  ${CASE}"
+}
+
+# Claude Code is "detected" through this file; the harness PATH has no claude.
+detect_claude() {
+  : >"${HOME}/.claude.json"
+}
+
+ensure_pusher() {
+  [ -n "$PUSHER" ] && return 0
+  PUSHER="${CASE_ROOT}/pusher"
+  git clone -q "${CASE_ROOT}/remote.git" "$PUSHER" || die "could not clone the pusher"
+  is_repo_root "$PUSHER" || die "the pusher is not a repo of its own"
+}
+
+push_skill() {
+  ensure_pusher
+  mkdir -p "${PUSHER}/skills/$1"
+  printf -- '---\nname: %s\ndescription: harness fixture\n---\n\nFixture.\n' "$1" \
+    >"${PUSHER}/skills/$1/SKILL.md"
+  git -C "$PUSHER" add -A
+  git -C "$PUSHER" commit -qm "add skill $1"
+  git -C "$PUSHER" push -q origin main
+}
+
+push_file() {
+  ensure_pusher
+  printf '%s\n' "$2" >"${PUSHER}/$1"
+  git -C "$PUSHER" add -A
+  git -C "$PUSHER" commit -qm "add $1"
+  git -C "$PUSHER" push -q origin main
+}
+
+install_skills() {
+  OUT="$(bash "${CLONE}/install.sh" "$@" 2>&1)"
+  INSTALL_RC=$?
+  printf '%s\n' "$OUT" >>"${CASE_ROOT}/install.log"
+  return $INSTALL_RC
+}
+
+install_rules() {
+  OUT="$(bash "${CLONE}/install-opinionated-rules.sh" "$@" 2>&1)"
+  INSTALL_RC=$?
+  printf '%s\n' "$OUT" >>"${CASE_ROOT}/install.log"
+  return $INSTALL_RC
+}
+
+run_hook() {
+  bash "${CLONE}/lib/auto-update.sh" --json
+}
+
+run_hook_plain() {
+  bash "${CLONE}/lib/auto-update.sh"
+}
+
+make_due() {
+  rm -f "${STATE}/stamp"
+}
+
+log_text() {
+  cat "${STATE}/log" 2>/dev/null
+}
+
+record_line() {
+  awk -F '\t' -v s="$1" -v t="$2" '$1 == s && $4 == t { line = $0 } END { print line }' \
+    "${STATE}/invocations" 2>/dev/null
+}
+
+record_field() {
+  record_line "$1" "$2" | awk -F '\t' -v n="$3" '{ print $n }'
+}
+
+# A shim that always fails, for staging a missing or broken tool.
+broken_shim() {
+  printf '#!/bin/sh\nexit 127\n' >"${CASE_ROOT}/bin/$1"
+  chmod +x "${CASE_ROOT}/bin/$1"
+}
+
+# --- cases -----------------------------------------------------------------
+
+case_up_to_date() {
+  detect_claude
+  install_skills
+  make_due
+  local head_before out
+  head_before="$(git -C "$CLONE" rev-parse HEAD)"
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_eq "HEAD" "$head_before" "$(git -C "$CLONE" rev-parse HEAD)"
+}
+
+case_behind() {
+  detect_claude
+  install_skills
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_eq "HEAD" "$(git -C "$PUSHER" rev-parse HEAD)" "$(git -C "$CLONE" rev-parse HEAD)"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+  assert_link "${HOME}/.agents/skills/zz-harness-skill"
+}
+
+case_replay_after_manual_pull() {
+  detect_claude
+  install_skills
+  push_skill zz-harness-skill
+  git -C "$CLONE" pull -q --ff-only
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+}
+
+case_fresh_install_no_replay() {
+  detect_claude
+  install_skills
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_not_contains "log" "$(log_text)" "Agents dir ->"
+}
+
+case_partial_rerun() {
+  detect_claude
+  install_skills
+  install_rules
+  push_skill zz-harness-skill
+  git -C "$CLONE" pull -q --ff-only
+  install_skills
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_contains "log" "$(log_text)" "Rules ->"
+  assert_not_contains "log" "$(log_text)" "Skills ->"
+}
+
+case_two_targets() {
+  detect_claude
+  install_skills
+  install_skills --skills-dir "${HOME}/other/skills"
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+  assert_link "${HOME}/other/skills/zz-harness-skill"
+}
+
+case_target_removed() {
+  detect_claude
+  install_skills
+  install_skills --skills-dir "${HOME}/other/skills"
+  rm -rf "${HOME}/other/skills"
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_eq "dropped record" "" "$(record_line install.sh "${HOME}/other/skills")"
+  assert_file_missing "${HOME}/other/skills"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+}
+
+case_dirty() {
+  detect_claude
+  install_skills
+  echo "local edit" >>"${CLONE}/README.md"
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "uncommitted changes"
+  assert_message_contains "$out" "$CLONE"
+
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+
+  git -C "$CLONE" checkout -q -- README.md
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+
+  echo "local edit again" >>"${CLONE}/README.md"
+  make_due
+  out="$(run_hook)"
+  assert_message_contains "$out" "uncommitted changes"
+}
+
+case_second_error_reported() {
+  detect_claude
+  install_skills
+  echo "local edit" >>"${CLONE}/README.md"
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "uncommitted changes"
+
+  git -C "$CLONE" commit -qam "local commit"
+  push_skill zz-harness-skill
+  make_due
+  out="$(run_hook)"
+  assert_message_contains "$out" "commits that are not on"
+}
+
+case_untracked_conflict() {
+  detect_claude
+  install_skills
+  push_file conflict.txt "from upstream"
+  printf 'mine\n' >"${CLONE}/conflict.txt"
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "conflict.txt"
+  assert_message_contains "$out" "could not update"
+}
+
+case_replay_failure() {
+  detect_claude
+  install_skills
+  push_skill zz-harness-skill
+  chmod 500 "${HOME}/.claude/skills"
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "install.sh failed"
+  assert_message_contains "$out" "Run it by hand"
+
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_contains "log" "$(log_text)" "Skills ->"
+
+  chmod 700 "${HOME}/.claude/skills"
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+}
+
+case_diverged() {
+  detect_claude
+  install_skills
+  printf 'local\n' >"${CLONE}/local-only.txt"
+  git -C "$CLONE" add local-only.txt
+  git -C "$CLONE" commit -qm "local commit"
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "commits that are not on"
+  assert_message_contains "$out" "log @{u}.."
+}
+
+case_non_default_branch() {
+  detect_claude
+  install_skills
+  ensure_pusher
+  git -C "$PUSHER" checkout -qb feature
+  git -C "$PUSHER" push -q -u origin feature
+  git -C "$CLONE" fetch -q
+  git -C "$CLONE" checkout -q -b feature --track origin/feature
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "does not track"
+  assert_message_contains "$out" "checkout main"
+}
+
+case_other_name_tracking_default() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" checkout -q -b work --track origin/main
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+}
+
+case_detached() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" checkout -q --detach HEAD
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "detached HEAD"
+  assert_message_contains "$out" "checkout main"
+}
+
+case_no_upstream() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" branch --unset-upstream
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "no upstream"
+  assert_message_contains "$out" "--set-upstream-to origin/main"
+}
+
+case_offline() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" remote set-url origin /nonexistent-remote.git
+  make_due
+  local out now stamp
+  now="$(date +%s)"
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  stamp="$(cat "${STATE}/stamp")"
+  if [ "$((stamp - now))" -gt 3660 ] || [ "$((stamp - now))" -lt 3540 ]; then
+    fail "stamp: expected about an hour ahead, got $((stamp - now))s"
+  fi
+  [ -f "${STATE}/offline-since" ] || fail "offline-since was not created"
+}
+
+case_offline_for_a_week() {
+  detect_claude
+  install_skills
+  local url out
+  url="$(git -C "$CLONE" remote get-url origin)"
+  git -C "$CLONE" remote set-url origin /nonexistent-remote.git
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+
+  printf '%s\n' "$(( $(date +%s) - 8 * 86400 ))" >"${STATE}/offline-since"
+  make_due
+  out="$(run_hook)"
+  assert_message_contains "$out" "for a week"
+  assert_message_contains "$out" "/nonexistent-remote.git"
+
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+
+  git -C "$CLONE" remote set-url origin "$url"
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_file_missing "${STATE}/offline-since"
+}
+
+case_fetch_hang() {
+  detect_claude
+  install_skills
+  printf '#!/bin/sh\nsleep 30\n' >"${CASE_ROOT}/bin/ssh"
+  chmod +x "${CASE_ROOT}/bin/ssh"
+  git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
+  make_due
+  local started ended out
+  started="$(date +%s)"
+  out="$(run_hook)"
+  ended="$(date +%s)"
+  assert_stdout_is '{}' "$out"
+  if [ "$((ended - started))" -gt 9 ]; then
+    fail "fetch watchdog: took $((ended - started))s"
+  fi
+  [ -f "${STATE}/offline-since" ] || fail "a hung fetch should count as offline"
+}
+
+case_ssh_guard() {
+  detect_claude
+  install_skills
+  local log="${CASE_ROOT}/ssh-argv"
+  printf '#!/bin/sh\necho "$@" >> %s\nenv | grep GIT_SSH_COMMAND >> %s.env\nexit 255\n' \
+    "$log" "$log" >"${CASE_ROOT}/bin/ssh"
+  chmod +x "${CASE_ROOT}/bin/ssh"
+  cp "${CASE_ROOT}/bin/ssh" "${CASE_ROOT}/bin/plink"
+  git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
+
+  make_due
+  run_hook >/dev/null
+  assert_contains "ssh argv" "$(cat "$log" 2>/dev/null)" "-o BatchMode=yes"
+  assert_contains "ssh argv" "$(cat "$log" 2>/dev/null)" "-o ConnectTimeout=5"
+
+  # A wrapper we do not recognise gets no flags: plink rejects -o.
+  : >"$log"
+  git -C "$CLONE" config core.sshCommand "${CASE_ROOT}/bin/plink"
+  make_due
+  run_hook >/dev/null
+  assert_not_contains "plink argv" "$(cat "$log" 2>/dev/null)" "-o BatchMode=yes"
+  git -C "$CLONE" config --unset core.sshCommand
+
+  # GIT_SSH is next in git's precedence, so we must not export over it.
+  : >"$log"
+  : >"${log}.env"
+  make_due
+  export GIT_SSH="${CASE_ROOT}/bin/ssh"
+  run_hook >/dev/null
+  unset GIT_SSH
+  assert_eq "GIT_SSH_COMMAND seen by GIT_SSH" "" "$(cat "${log}.env" 2>/dev/null)"
+}
+
+case_throttled() {
+  detect_claude
+  install_skills
+  make_due
+  run_hook >/dev/null
+  printf 'sentinel\n' >"${STATE}/log"
+  printf '%s\n' "$(( $(date +%s) + 99999 ))" >"${STATE}/stamp"
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_eq "log untouched" "sentinel" "$(log_text)"
+}
+
+case_lock_held() {
+  detect_claude
+  install_skills
+  make_due
+  mkdir -p "${STATE}/lock"
+  printf '%s\n' "$(date +%s)" >"${STATE}/lock/ts"
+  printf 'sentinel\n' >"${STATE}/log"
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_eq "log untouched" "sentinel" "$(log_text)"
+  [ -d "${STATE}/lock" ] || fail "someone else's lock was removed"
+}
+
+case_stale_lock() {
+  detect_claude
+  install_skills
+  make_due
+  mkdir -p "${STATE}/lock"
+  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  printf 'sentinel\n' >"${STATE}/log"
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_not_contains "log" "$(log_text)" "sentinel"
+  [ -d "${STATE}/lock" ] && fail "the lock should be released at exit"
+  return 0
+}
+
+case_state_in_worktree() {
+  detect_claude
+  install_skills
+  git -C "$CLONE" worktree add -q --detach "${CASE_ROOT}/wt" >/dev/null 2>&1
+  bash "${CASE_ROOT}/wt/lib/auto-update.sh" --json >/dev/null
+  [ -d "${CLONE}/.git/worktrees/wt/agent-toolkit" ] \
+    || fail "expected state under .git/worktrees/wt/agent-toolkit"
+}
+
+case_state_in_submodule() {
+  detect_claude
+  local super="${CASE_ROOT}/super"
+  mkdir -p "$super"
+  git -c init.defaultBranch=main init -q "$super"
+  git -C "$super" -c protocol.file.allow=always submodule add -q \
+    "${CASE_ROOT}/remote.git" sub >/dev/null 2>&1
+  git -C "$super" commit -qm "add submodule"
+  bash "${super}/sub/lib/auto-update.sh" --json >/dev/null
+  [ -d "${super}/.git/modules/sub/agent-toolkit" ] \
+    || fail "expected state under .git/modules/sub/agent-toolkit"
+}
+
+case_copies_recorded() {
+  detect_claude
+  install_skills
+  # Stage what a Windows install leaves behind: the record says copies, and the
+  # entries are real directories the installer will not touch.
+  local target="${HOME}/.claude/skills" entry name
+  awk -F '\t' 'BEGIN { OFS = "\t" } { $6 = 1; print }' "${STATE}/invocations" \
+    >"${STATE}/invocations.new"
+  mv "${STATE}/invocations.new" "${STATE}/invocations"
+  for entry in "$target"/*; do
+    name="$(basename "$entry")"
+    rm -rf "$entry"
+    mkdir -p "${target}/${name}"
+    : >"${target}/${name}/SKILL.md"
+  done
+
+  push_skill zz-harness-skill
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_message_contains "$out" "holds copies rather than links"
+  assert_message_contains "$out" "--force"
+  assert_message_contains "$out" "$target"
+  assert_eq "copies flag stays set" "1" "$(record_field install.sh "$target" 6)"
+
+  push_skill zz-harness-skill-two
+  make_due
+  out="$(run_hook)"
+  assert_message_contains "$out" "holds copies rather than links"
+}
+
+case_two_reasons() {
+  detect_claude
+  install_skills
+  install_skills --skills-dir "${HOME}/other/skills"
+  local other="${HOME}/other/skills" entry name
+  awk -F '\t' -v t="$other" 'BEGIN { OFS = "\t" } $4 == t { $6 = 1 } { print }' \
+    "${STATE}/invocations" >"${STATE}/invocations.new"
+  mv "${STATE}/invocations.new" "${STATE}/invocations"
+  for entry in "$other"/*; do
+    name="$(basename "$entry")"
+    rm -rf "$entry"
+    mkdir -p "${other}/${name}"
+  done
+  chmod 500 "${HOME}/.claude/skills"
+
+  push_skill zz-harness-skill
+  make_due
+  local out msg lines
+  out="$(run_hook)"
+  msg="$(json_message "$out")"
+  lines="$(printf '%s\n' "$msg" | grep -c .)"
+  assert_eq "one line per reason" "2" "$lines"
+  assert_contains "message" "$msg" "install.sh failed"
+  assert_contains "message" "$msg" "holds copies rather than links"
+  chmod 700 "${HOME}/.claude/skills"
+}
+
+case_feedback_is_json_escaped() {
+  detect_claude
+  install_skills
+  push_file 'we"ird.txt' "from upstream"
+  printf 'mine\n' >"${CLONE}/we\"ird.txt"
+  make_due
+  local out msg
+  out="$(run_hook)"
+  msg="$(json_message "$out")"
+  if [ -z "$msg" ]; then
+    fail "stdout did not parse as JSON: $out"
+  fi
+  assert_contains "message" "$msg" 'we"ird.txt'
+}
+
+case_moved_clone() {
+  detect_claude
+  install_skills
+  mv "$CLONE" "${CASE_ROOT}/clone2"
+  CLONE="${CASE_ROOT}/clone2"
+  STATE="${CLONE}/.git/agent-toolkit"
+  install_skills
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_contains "hook command" "$(settings_get hooks.SessionStart.0.hooks.0.command)" \
+    "${CASE_ROOT}/clone2/lib/auto-update.sh"
+}
+
+case_drifted_hook_entry() {
+  detect_claude
+  install_skills
+  /usr/bin/python3 - "$(settings_file)" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path))
+group = data["hooks"]["SessionStart"][0]
+group["matcher"] = "startup|resume"
+group["hooks"][0]["timeout"] = 99
+group["hooks"][0]["extra"] = True
+json.dump(data, open(path, "w"), indent=2)
+PY
+  push_skill zz-harness-skill
+  make_due
+  run_hook >/dev/null
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_eq "timeout" "10" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
+  assert_eq "matcher kept" "startup|resume" "$(settings_get hooks.SessionStart.0.matcher)"
+  assert_eq "extra key dropped" "" "$(settings_get hooks.SessionStart.0.hooks.0.extra)"
+}
+
+case_opt_out_and_back_in() {
+  detect_claude
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+
+  install_skills --no-auto-update
+  assert_contains "installer output" "$OUT" "opted out"
+  assert_eq "removed" "0" "$(hook_count)"
+  [ -f "${STATE}/opt-out" ] || fail "opt-out marker was not created"
+
+  install_rules
+  assert_contains "installer output" "$OUT" "opted out"
+  assert_eq "still removed" "0" "$(hook_count)"
+
+  make_due
+  local out
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_not_contains "log" "$(log_text)" "Agents dir ->"
+
+  install_skills --auto-update
+  assert_eq "back" "1" "$(hook_count)"
+  assert_file_missing "${STATE}/opt-out"
+}
+
+case_claude_not_detected() {
+  install_skills
+  assert_contains "installer output" "$OUT" "no Claude Code found"
+  assert_link "${HOME}/.claude/skills/handover"
+  assert_file_missing "$(settings_file)"
+}
+
+case_git_unusable() {
+  detect_claude
+  broken_shim git
+  install_skills
+  assert_eq "installer exit code" "0" "$INSTALL_RC"
+  assert_contains "installer output" "$OUT" "not a git work tree"
+  assert_link "${HOME}/.claude/skills/handover"
+  assert_file_missing "${STATE}/invocations"
+}
+
+case_symlinked_clone_path() {
+  detect_claude
+  ln -s "$CLONE" "${CASE_ROOT}/clone-link"
+  bash "${CASE_ROOT}/clone-link/install.sh" >>"${CASE_ROOT}/install.log" 2>&1
+  assert_link_target "${HOME}/.agents/skills/handover" "${CLONE}/skills/handover"
+
+  # What an install from before physical REPO_DIR left behind: links through
+  # the symlinked path, which the installer must re-point rather than skip.
+  local entry name out
+  for entry in "${HOME}/.agents/skills"/*; do
+    name="$(basename "$entry")"
+    rm -f "$entry"
+    ln -s "${CASE_ROOT}/clone-link/skills/${name}" "$entry"
+  done
+  OUT="$(bash "${CASE_ROOT}/clone-link/install.sh" 2>&1)"
+  assert_not_contains "installer output" "$OUT" "skip"
+  assert_link_target "${HOME}/.agents/skills/handover" "${CLONE}/skills/handover"
+
+  push_skill zz-harness-skill
+  make_due
+  out="$(run_hook)"
+  assert_stdout_is '{}' "$out"
+  assert_not_contains "log" "$(log_text)" "skip"
+  assert_link "${HOME}/.claude/skills/zz-harness-skill"
+}
+
+case_non_claude_skills_dir() {
+  detect_claude
+  install_skills --skills-dir "${HOME}/proj/.claude/skills"
+  assert_contains "installer output" "$OUT" "not Claude Code's own dir"
+  assert_contains "installer output" "$OUT" "lib/auto-update.sh"
+  assert_eq "nothing registered" "0" "$(hook_count)"
+}
+
+case_no_upstream_at_install() {
+  detect_claude
+  git -C "$CLONE" branch --unset-upstream
+  install_skills
+  assert_contains "installer output" "$OUT" "no upstream"
+  assert_eq "nothing registered" "0" "$(hook_count)"
+}
+
+case_apostrophe_in_clone_path() {
+  detect_claude
+  mkdir -p "${CASE_ROOT}/it's"
+  git clone -q "${CASE_ROOT}/remote.git" "${CASE_ROOT}/it's/clone"
+  CLONE="${CASE_ROOT}/it's/clone"
+  STATE="${CLONE}/.git/agent-toolkit"
+  install_skills
+  assert_contains "installer output" "$OUT" "apostrophe"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_eq "nothing registered" "0" "$(hook_count)"
+}
+
+case_settings_created() {
+  detect_claude
+  install_skills
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_eq "one group" "1" "$(group_count)"
+  assert_eq "matcher" "startup" "$(settings_get hooks.SessionStart.0.matcher)"
+  assert_eq "timeout" "10" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
+  assert_eq "top-level keys" '["hooks"]' "$(top_level_keys)"
+}
+
+case_settings_keeps_foreign_hooks() {
+  detect_claude
+  mkdir -p "${HOME}/.claude"
+  cat >"$(settings_file)" <<'JSON'
+{
+  "model": "opus",
+  "hooks": {
+    "Stop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "echo stop" }] }],
+    "SessionStart": [
+      { "matcher": "startup", "hooks": [{ "type": "command", "command": "echo foreign" }] }
+    ]
+  }
+}
+JSON
+  install_skills
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_eq "model kept" "opus" "$(settings_get model)"
+  assert_contains "Stop kept" "$(settings_get hooks.Stop)" "echo stop"
+  assert_contains "foreign group kept" "$(settings_get hooks.SessionStart.0)" "echo foreign"
+  assert_contains "ours appended" "$(settings_get hooks.SessionStart.1)" "lib/auto-update.sh"
+}
+
+case_settings_unparsable() {
+  detect_claude
+  mkdir -p "${HOME}/.claude"
+  printf '{ nope' >"$(settings_file)"
+  install_skills
+  assert_contains "installer output" "$OUT" "not valid JSON"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_eq "file untouched" '{ nope' "$(cat "$(settings_file)")"
+}
+
+case_interpreter_fallthrough() {
+  detect_claude
+  broken_shim python3
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    install_skills
+    assert_eq "node did the merge" "1" "$(hook_count)"
+    rm -f "$(settings_file)"
+    broken_shim node
+  else
+    echo "    (no node available, skipping the node leg)"
+  fi
+  install_skills
+  assert_eq "jq did the merge" "1" "$(hook_count)"
+}
+
+case_no_interpreter() {
+  detect_claude
+  broken_shim python3
+  broken_shim node
+  broken_shim jq
+  install_skills
+  assert_contains "installer output" "$OUT" "no working python3, node or jq"
+  assert_contains "installer output" "$OUT" "hooks.SessionStart"
+  assert_file_missing "$(settings_file)"
+}
+
+case_settings_written_only_on_change() {
+  detect_claude
+  install_skills
+  local before
+  before="$(mtime "$(settings_file)")"
+  sleep 1
+  install_skills
+  assert_contains "installer output" "$OUT" "Already registered"
+  assert_eq "settings mtime" "$before" "$(mtime "$(settings_file)")"
+}
+
+case_plain_output_mode() {
+  detect_claude
+  install_skills
+  echo "local edit" >>"${CLONE}/README.md"
+  make_due
+  local out
+  out="$(run_hook_plain)"
+  assert_contains "plain output" "$out" "uncommitted changes"
+  assert_not_contains "plain output" "$out" "systemMessage"
+
+  make_due
+  out="$(run_hook_plain)"
+  assert_eq "plain output when silent" "" "$out"
+}
+
+CASES="
+up_to_date
+behind
+replay_after_manual_pull
+fresh_install_no_replay
+partial_rerun
+two_targets
+target_removed
+dirty
+second_error_reported
+untracked_conflict
+replay_failure
+diverged
+non_default_branch
+other_name_tracking_default
+detached
+no_upstream
+offline
+offline_for_a_week
+fetch_hang
+ssh_guard
+throttled
+lock_held
+stale_lock
+state_in_worktree
+state_in_submodule
+copies_recorded
+two_reasons
+feedback_is_json_escaped
+moved_clone
+drifted_hook_entry
+opt_out_and_back_in
+claude_not_detected
+git_unusable
+symlinked_clone_path
+non_claude_skills_dir
+no_upstream_at_install
+apostrophe_in_clone_path
+settings_created
+settings_keeps_foreign_hooks
+settings_unparsable
+interpreter_fallthrough
+no_interpreter
+settings_written_only_on_change
+plain_output_mode
+"
+
+# The clone under test is the working tree, not git history: the harness has to
+# see uncommitted work. test/ is left out, it is not installed anyway and it
+# holds this run's own output.
+build_template() {
+  local src="${RUNS}/_src"
+  mkdir -p "$src"
+  (cd "$REPO_ROOT" && tar --exclude './.git' --exclude './.agents' --exclude './.idea' \
+      --exclude './.superpowers' --exclude './test' --exclude '.DS_Store' -cf - .) \
+    | (cd "$src" && tar -xf -)
+  git -c init.defaultBranch=main init -q "$src" || die "git init failed in $src"
+  is_repo_root "$src" || die "$src did not become a repo"
+  git -C "$src" add -A || die "git add failed in $src"
+  git -C "$src" commit -qm "harness snapshot" || die "git commit failed in $src"
+  git clone -q --bare "$src" "$TEMPLATE" || die "could not build the template remote"
+}
+
+mkdir -p "$RUNS"
+export HOME="${RUNS}/_home"
+mkdir -p "$HOME"
+export PATH="$BASE_PATH"
+build_template
+
+WANTED="$*"
+for name in $CASES; do
+  if [ -n "$WANTED" ]; then
+    case " $WANTED " in *" $name "*) ;; *) continue ;; esac
+  fi
+  new_case "$name"
+  "case_${name}"
+  RAN=$((RAN + 1))
+  if [ "$CASE_FAILS" -gt 0 ]; then
+    TOTAL_FAILS=$((TOTAL_FAILS + 1))
+  fi
+done
+
+echo
+if [ "$TOTAL_FAILS" -eq 0 ]; then
+  echo "All ${RAN} cases passed. Output: ${RUNS}"
+  exit 0
+fi
+echo "${TOTAL_FAILS} of ${RAN} cases failed. Output: ${RUNS}"
+exit 1

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -98,6 +98,15 @@ assert_file_missing() {
   if [ -e "$1" ]; then fail "expected $1 to be gone"; fi
 }
 
+# A hook that dies on line 1 satisfies any assertion about what is absent. The
+# stamp is the cheapest proof a run got past the throttle.
+assert_ran() {
+  local due
+  due="$(cat "${STATE}/stamp" 2>/dev/null)"
+  case "$due" in ''|*[!0-9]*) fail "no stamp: the hook never ran"; return 0 ;; esac
+  [ "$due" -gt "$(date +%s)" ] || fail "the hook left a stale stamp: $due"
+}
+
 # --- helpers ---------------------------------------------------------------
 
 json_message() {
@@ -274,6 +283,7 @@ case_up_to_date() {
   head_before="$(git -C "$CLONE" rev-parse HEAD)"
   out="$(run_hook)"
   assert_stdout_is '{}' "$out"
+  assert_ran
   assert_eq "HEAD" "$head_before" "$(git -C "$CLONE" rev-parse HEAD)"
 }
 
@@ -308,6 +318,7 @@ case_fresh_install_no_replay() {
   local out
   out="$(run_hook)"
   assert_stdout_is '{}' "$out"
+  assert_ran
   assert_not_contains "log" "$(log_text)" "Agents dir ->"
 }
 
@@ -572,6 +583,7 @@ case_ssh_guard() {
   git -C "$CLONE" config core.sshCommand "${CASE_ROOT}/bin/plink"
   make_due
   run_hook >/dev/null
+  assert_contains "plink argv" "$(cat "$log" 2>/dev/null)" "git-upload-pack"
   assert_not_contains "plink argv" "$(cat "$log" 2>/dev/null)" "-o BatchMode=yes"
   git -C "$CLONE" config --unset core.sshCommand
 
@@ -590,6 +602,7 @@ case_throttled() {
   install_skills
   make_due
   run_hook >/dev/null
+  assert_ran
   printf 'sentinel\n' >"${STATE}/log"
   printf '%s\n' "$(( $(date +%s) + 99999 ))" >"${STATE}/stamp"
   local out
@@ -608,6 +621,7 @@ case_lock_held() {
   local out
   out="$(run_hook)"
   assert_stdout_is '{}' "$out"
+  assert_ran
   assert_eq "log untouched" "sentinel" "$(log_text)"
   [ -d "${STATE}/lock" ] || fail "someone else's lock was removed"
 }
@@ -783,6 +797,10 @@ case_opt_out_and_back_in() {
   install_skills --auto-update
   assert_eq "back" "1" "$(hook_count)"
   assert_file_missing "${STATE}/opt-out"
+
+  make_due
+  run_hook >/dev/null
+  assert_ran
 }
 
 case_claude_not_detected() {
@@ -897,12 +915,78 @@ JSON
   assert_contains "ours appended" "$(settings_get hooks.SessionStart.1)" "lib/auto-update.sh"
 }
 
+# Foreign handlers wrapped around ours, a drifted copy of ours in a second
+# group, and a group that came in empty. Only python3 ever meets any of it.
+write_hard_settings() {
+  mkdir -p "${HOME}/.claude"
+  cat >"$(settings_file)" <<'JSON'
+{
+  "model": "opus",
+  "hooks": {
+    "Stop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "echo stop" }] }],
+    "SessionStart": [
+      { "matcher": "startup", "hooks": [
+        { "type": "command", "command": "echo before" },
+        { "type": "command", "command": "bash '/gone/lib/auto-update.sh' --json", "timeout": 3 },
+        { "type": "command", "command": "echo after" }
+      ] },
+      { "matcher": "resume", "hooks": [] },
+      { "matcher": "clear", "hooks": [
+        { "type": "command", "command": "bash '/gone/lib/auto-update.sh' --json", "timeout": 10 }
+      ] }
+    ]
+  }
+}
+JSON
+}
+
+# python3, node and jq are three implementations of one algorithm, so run the
+# same file through each and compare what comes out.
+case_settings_engines_agree() {
+  detect_claude
+  local registered removed
+
+  write_hard_settings
+  install_skills
+  registered="$(cat "$(settings_file)")"
+  assert_eq "one handler" "1" "$(hook_count)"
+  assert_contains "foreign before kept" "$registered" "echo before"
+  assert_contains "foreign after kept" "$registered" "echo after"
+  assert_contains "Stop kept" "$registered" "echo stop"
+  assert_eq "empty group kept, ours-only group dropped" "2" "$(group_count)"
+  install_skills --no-auto-update
+  removed="$(cat "$(settings_file)")"
+  assert_eq "python3 removed ours" "0" "$(hook_count)"
+
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim python3
+    write_hard_settings
+    install_skills --auto-update
+    assert_eq "node register" "$registered" "$(cat "$(settings_file)")"
+    install_skills --no-auto-update
+    assert_eq "node remove" "$removed" "$(cat "$(settings_file)")"
+    broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
+  else
+    echo "    (no node available, skipping the node leg)"
+    broken_shim python3
+    broken_shim node
+  fi
+
+  write_hard_settings
+  install_skills --auto-update
+  assert_eq "jq register" "$registered" "$(cat "$(settings_file)")"
+  install_skills --no-auto-update
+  assert_eq "jq remove" "$removed" "$(cat "$(settings_file)")"
+}
+
 case_settings_unparsable() {
   detect_claude
   mkdir -p "${HOME}/.claude"
   printf '{ nope' >"$(settings_file)"
   install_skills
-  assert_contains "installer output" "$OUT" "not valid JSON"
+  assert_contains "installer output" "$OUT" "cannot work with the JSON in"
   assert_contains "installer output" "$OUT" "hooks.SessionStart"
   assert_eq "file untouched" '{ nope' "$(cat "$(settings_file)")"
 }
@@ -922,6 +1006,30 @@ case_interpreter_fallthrough() {
   fi
   install_skills
   assert_eq "jq did the merge" "1" "$(hook_count)"
+}
+
+# Every other remove test runs under python3. node and jq have to drop the
+# handler and the emptied group too.
+case_remove_interpreter_fallthrough() {
+  detect_claude
+  broken_shim python3
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    install_skills
+    assert_eq "node registered" "1" "$(hook_count)"
+    install_skills --no-auto-update
+    assert_eq "node removed" "0" "$(hook_count)"
+    assert_eq "node dropped the group" "0" "$(group_count)"
+    broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
+  else
+    echo "    (no node available, skipping the node leg)"
+  fi
+  install_skills --auto-update
+  assert_eq "jq registered" "1" "$(hook_count)"
+  install_skills --no-auto-update
+  assert_eq "jq removed" "0" "$(hook_count)"
+  assert_eq "jq dropped the group" "0" "$(group_count)"
 }
 
 case_no_interpreter() {
@@ -1038,8 +1146,10 @@ detached_at_install
 apostrophe_in_clone_path
 settings_created
 settings_keeps_foreign_hooks
+settings_engines_agree
 settings_unparsable
 interpreter_fallthrough
+remove_interpreter_fallthrough
 no_interpreter
 settings_written_only_on_change
 settings_symlinked

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -948,6 +948,24 @@ case_apostrophe_in_clone_path() {
   assert_eq "nothing registered" "0" "$(hook_count)"
 }
 
+case_apostrophe_in_replay_advice() {
+  detect_claude
+  mkdir -p "${CASE_ROOT}/it's"
+  git clone -q "${CASE_ROOT}/remote.git" "${CASE_ROOT}/it's/clone"
+  CLONE="${CASE_ROOT}/it's/clone"
+  STATE="${CLONE}/.git/agent-toolkit"
+  install_skills
+  push_skill zz-harness-skill
+  chmod 500 "${HOME}/.claude/skills"
+  make_due
+  local out
+  out="$(run_hook)"
+  chmod 700 "${HOME}/.claude/skills"
+  assert_message_contains "$out" "install.sh failed"
+  assert_message_contains "$out" "cannot be safely quoted"
+  assert_not_contains "message" "$(json_message "$out")" "bash '"
+}
+
 case_settings_created() {
   detect_claude
   install_skills
@@ -1311,6 +1329,7 @@ non_claude_skills_dir
 no_upstream_at_install
 detached_at_install
 apostrophe_in_clone_path
+apostrophe_in_replay_advice
 settings_created
 settings_keeps_foreign_hooks
 settings_engines_agree

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -54,18 +54,18 @@ is_repo_root() {
 # it before the first case even runs.
 python_usable() {
   [ -n "$PYTHON" ] || return 1
-  local pid i=0
+  local pid ticks=0
   "$PYTHON" -c 'import json' >/dev/null 2>&1 &
   pid=$!
   while kill -0 "$pid" 2>/dev/null; do
-    if [ "$i" -ge 3 ]; then
+    if [ "$ticks" -ge 30 ]; then
       pkill -P "$pid" 2>/dev/null
       kill "$pid" 2>/dev/null
       wait "$pid" 2>/dev/null
       return 1
     fi
-    sleep 1
-    i=$((i + 1))
+    sleep 0.1
+    ticks=$((ticks + 1))
   done
   wait "$pid"
 }
@@ -310,6 +310,17 @@ write_shim() {
 # A shim that always fails, for staging a missing or broken tool.
 broken_shim() {
   write_shim "$1" $'#!/bin/sh\nexit 127'
+}
+
+# One settings_merge call on its own, for the shapes no installer run reaches.
+settings_merge_rc() {
+  ( . "${CLONE}/lib/install-utils.sh"
+    settings_merge "$1" "$2" "bash '${CLONE}/lib/auto-update.sh' --json" )
+}
+
+# A lock older than the stale threshold, by a margin.
+stale_ts() {
+  printf '%s' "$(( $(date +%s) - 4000 ))"
 }
 
 # --- cases -----------------------------------------------------------------
@@ -709,7 +720,7 @@ case_stale_lock() {
   install_skills
   make_due
   mkdir -p "${STATE}/lock"
-  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  printf '%s\n' "$(stale_ts)" >"${STATE}/lock/ts"
   printf 'sentinel\n' >"${STATE}/log"
   local out
   out="$(run_hook)"
@@ -741,7 +752,7 @@ case_lock_not_ours() {
 
   # Takeover goes by the timestamp, not the token: someone else's stale lock is
   # still ours to claim.
-  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  printf '%s\n' "$(stale_ts)" >"${STATE}/lock/ts"
   make_due
   run_hook >/dev/null
   assert_file_missing "${STATE}/lock"
@@ -753,7 +764,7 @@ case_lock_takeover_loser() {
   install_skills
   make_due
   mkdir -p "${STATE}/lock"
-  printf '%s\n' "$(( $(date +%s) - 120 ))" >"${STATE}/lock/ts"
+  printf '%s\n' "$(stale_ts)" >"${STATE}/lock/ts"
   printf 'someone-else\n' >"${STATE}/lock/owner"
   chmod 400 "${STATE}/lock/owner"
   printf 'sentinel\n' >"${STATE}/log"
@@ -887,7 +898,7 @@ path = sys.argv[1]
 data = json.load(open(path))
 group = data["hooks"]["SessionStart"][0]
 group["matcher"] = "startup|resume"
-group["hooks"][0]["timeout"] = 99
+group["hooks"][0]["timeout"] = 3
 group["hooks"][0]["extra"] = True
 json.dump(data, open(path, "w"), indent=2)
 PY
@@ -895,9 +906,23 @@ PY
   make_due
   run_hook >/dev/null
   assert_eq "one handler" "1" "$(hook_count)"
-  assert_eq "timeout" "10" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
+  assert_eq "lowered timeout reset" "20" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
   assert_eq "matcher kept" "startup|resume" "$(settings_get hooks.SessionStart.0.matcher)"
   assert_eq "extra key dropped" "" "$(settings_get hooks.SessionStart.0.hooks.0.extra)"
+
+  # A timeout the user raised is theirs to keep: the daily replay must not
+  # take their escape hatch away.
+  "$PYTHON" - "$(settings_file)" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path))
+data["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = 99
+json.dump(data, open(path, "w"), indent=2)
+PY
+  push_skill zz-harness-skill-2
+  make_due
+  run_hook >/dev/null
+  assert_eq "raised timeout kept" "99" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
 }
 
 case_opt_out_and_back_in() {
@@ -927,6 +952,32 @@ case_opt_out_and_back_in() {
   make_due
   run_hook >/dev/null
   assert_ran
+}
+
+# An explicit opt-out has to reach the hook even when git cannot read the
+# clone, or the entry outlives the clone and fails at every session start.
+case_opt_out_without_git() {
+  detect_claude
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+  broken_shim git
+  install_skills --no-auto-update
+  assert_eq "installer exit code" "0" "$INSTALL_RC"
+  assert_contains "installer output" "$OUT" "removed our hook"
+  assert_contains "installer output" "$OUT" "not recorded"
+  assert_eq "removed" "0" "$(hook_count)"
+}
+
+# The hook names the clone, so opting out from any install of it removes it,
+# a project's skills dir included.
+case_opt_out_from_other_target() {
+  detect_claude
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+  install_skills --skills-dir "${HOME}/proj/.claude/skills" --no-auto-update
+  assert_contains "installer output" "$OUT" "removed our hook"
+  assert_eq "removed" "0" "$(hook_count)"
+  [ -f "${STATE}/opt-out" ] || fail "opt-out marker was not created"
 }
 
 case_marker_write_fails() {
@@ -1016,6 +1067,15 @@ case_non_claude_skills_dir() {
   assert_contains "installer output" "$OUT" "not Claude Code's own dir"
   assert_contains "installer output" "$OUT" "lib/auto-update.sh"
   assert_eq "nothing registered" "0" "$(hook_count)"
+
+  # Once the clone has its hook, that hook replays this install too, and the
+  # advice to add a second one would be wrong.
+  install_skills
+  assert_eq "registered" "1" "$(hook_count)"
+  install_skills --skills-dir "${HOME}/proj/.claude/skills"
+  assert_contains "installer output" "$OUT" "replays this install too"
+  assert_not_contains "installer output" "$OUT" "not Claude Code's own dir"
+  assert_eq "still one handler" "1" "$(hook_count)"
 }
 
 case_no_upstream_at_install() {
@@ -1090,7 +1150,7 @@ case_settings_created() {
   assert_eq "one handler" "1" "$(hook_count)"
   assert_eq "one group" "1" "$(group_count)"
   assert_eq "matcher" "startup" "$(settings_get hooks.SessionStart.0.matcher)"
-  assert_eq "timeout" "10" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
+  assert_eq "timeout" "20" "$(settings_get hooks.SessionStart.0.hooks.0.timeout)"
   assert_eq "top-level keys" '["hooks"]' "$(top_level_keys)"
 }
 
@@ -1128,7 +1188,7 @@ write_hard_settings() {
     "SessionStart": [
       { "matcher": "startup", "hooks": [
         { "type": "command", "command": "echo before" },
-        { "type": "command", "command": "bash '/gone/lib/auto-update.sh' --json", "timeout": 3 },
+        { "type": "command", "command": "bash '/gone/lib/auto-update.sh' --json", "timeout": 45 },
         { "type": "command", "command": "echo after" }
       ] },
       { "matcher": "resume", "hooks": [] },
@@ -1151,6 +1211,7 @@ case_settings_engines_agree() {
   install_skills
   registered="$(cat "$(settings_file)")"
   assert_eq "one handler" "1" "$(hook_count)"
+  assert_eq "raised timeout kept" "45" "$(settings_get hooks.SessionStart.0.hooks.1.timeout)"
   assert_contains "foreign before kept" "$registered" "echo before"
   assert_contains "foreign after kept" "$registered" "echo after"
   assert_contains "Stop kept" "$registered" "echo stop"
@@ -1289,6 +1350,88 @@ case_settings_null_hooks() {
   if [ -n "$REAL_JQ" ]; then
     ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
     assert_null_hooks_refused jq
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
+}
+
+# Windows editors leave a BOM; Claude Code reads past it, so the engines must
+# too, and drop it on the way out.
+case_settings_with_bom() {
+  detect_claude
+  mkdir -p "${HOME}/.claude"
+  local file
+  file="$(settings_file)"
+  printf '\357\273\277{ "model": "opus" }\n' >"$file"
+  install_skills
+  assert_eq "python3 registered" "1" "$(hook_count)"
+  assert_eq "model kept" "opus" "$(settings_get model)"
+
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim python3
+    broken_shim jq
+    printf '\357\273\277{ "model": "opus" }\n' >"$file"
+    install_skills
+    assert_eq "node registered" "1" "$(hook_count)"
+    broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
+  else
+    echo "    (no node available, skipping the node leg)"
+    broken_shim python3
+    broken_shim node
+  fi
+
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    printf '\357\273\277{ "model": "opus" }\n' >"$file"
+    install_skills
+    assert_eq "jq registered" "1" "$(hook_count)"
+  else
+    echo "    (no jq available, skipping the jq leg)"
+  fi
+}
+
+# Removing what is not there is a no-op in every engine: a SessionStart list
+# the user left empty is theirs, not a group we emptied.
+case_remove_with_nothing_of_ours() {
+  detect_claude
+  mkdir -p "${HOME}/.claude"
+  local file before rc
+  file="$(settings_file)"
+  before='{ "hooks": { "SessionStart": [] } }'
+  printf '%s\n' "$before" >"$file"
+  install_skills --no-auto-update
+  assert_contains "installer output" "$OUT" "opted out"
+  assert_eq "installer left the file alone" "$before" "$(cat "$file")"
+
+  rc=0
+  settings_merge_rc "$file" remove || rc=$?
+  assert_eq "python3: nothing to do" "2" "$rc"
+  assert_eq "python3: file untouched" "$before" "$(cat "$file")"
+
+  if [ -n "$REAL_NODE" ]; then
+    ln -sf "$REAL_NODE" "${CASE_ROOT}/bin/node"
+    broken_shim python3
+    broken_shim jq
+    rc=0
+    settings_merge_rc "$file" remove || rc=$?
+    assert_eq "node: nothing to do" "2" "$rc"
+    assert_eq "node: file untouched" "$before" "$(cat "$file")"
+    broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
+  else
+    echo "    (no node available, skipping the node leg)"
+    broken_shim python3
+    broken_shim node
+  fi
+
+  if [ -n "$REAL_JQ" ]; then
+    ln -sf "$REAL_JQ" "${CASE_ROOT}/bin/jq"
+    rc=0
+    settings_merge_rc "$file" remove || rc=$?
+    assert_eq "jq: nothing to do" "2" "$rc"
+    assert_eq "jq: file untouched" "$before" "$(cat "$file")"
   else
     echo "    (no jq available, skipping the jq leg)"
   fi
@@ -1482,6 +1625,8 @@ feedback_is_json_escaped
 moved_clone
 drifted_hook_entry
 opt_out_and_back_in
+opt_out_without_git
+opt_out_from_other_target
 marker_write_fails
 rules_installer_registers
 claude_not_detected
@@ -1499,6 +1644,8 @@ settings_engines_agree
 settings_unparsable
 settings_write_fails
 settings_null_hooks
+settings_with_bom
+remove_with_nothing_of_ours
 interpreter_fallthrough
 remove_interpreter_fallthrough
 no_interpreter

--- a/test/auto-update/run.sh
+++ b/test/auto-update/run.sh
@@ -241,10 +241,23 @@ record_field() {
   record_line "$1" "$2" | awk -F '\t' -v n="$3" '{ print $n }'
 }
 
+# Every shim goes through here. A plain > follows a symlink, and the node leg of
+# case_interpreter_fallthrough puts a link to the developer's own node in bin/ --
+# writing the stub straight to that path truncates their real binary.
+write_shim() {
+  local path="${CASE_ROOT}/bin/$1"
+  case "$CASE_ROOT" in
+    "${RUNS}"/?*) ;;
+    *) die "refusing to write a shim outside the run dir: $path" ;;
+  esac
+  rm -f "$path"
+  printf '%s\n' "$2" >"$path"
+  chmod +x "$path"
+}
+
 # A shim that always fails, for staging a missing or broken tool.
 broken_shim() {
-  printf '#!/bin/sh\nexit 127\n' >"${CASE_ROOT}/bin/$1"
-  chmod +x "${CASE_ROOT}/bin/$1"
+  write_shim "$1" $'#!/bin/sh\nexit 127'
 }
 
 # --- cases -----------------------------------------------------------------
@@ -522,8 +535,7 @@ case_offline_for_a_week() {
 case_fetch_hang() {
   detect_claude
   install_skills
-  printf '#!/bin/sh\nsleep 30\n' >"${CASE_ROOT}/bin/ssh"
-  chmod +x "${CASE_ROOT}/bin/ssh"
+  write_shim ssh $'#!/bin/sh\nsleep 30'
   git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
   make_due
   local started ended out
@@ -541,9 +553,8 @@ case_ssh_guard() {
   detect_claude
   install_skills
   local log="${CASE_ROOT}/ssh-argv"
-  printf '#!/bin/sh\necho "$@" >> %s\nenv | grep GIT_SSH_COMMAND >> %s.env\nexit 255\n' \
-    "$log" "$log" >"${CASE_ROOT}/bin/ssh"
-  chmod +x "${CASE_ROOT}/bin/ssh"
+  write_shim ssh "$(printf '#!/bin/sh\necho "$@" >> %s\nenv | grep GIT_SSH_COMMAND >> %s.env\nexit 255' \
+    "$log" "$log")"
   cp "${CASE_ROOT}/bin/ssh" "${CASE_ROOT}/bin/plink"
   git -C "$CLONE" remote set-url origin ssh://localhost/nope.git
 
@@ -888,6 +899,7 @@ case_interpreter_fallthrough() {
     assert_eq "node did the merge" "1" "$(hook_count)"
     rm -f "$(settings_file)"
     broken_shim node
+    "$REAL_NODE" -v >/dev/null 2>&1 || fail "the node shim clobbered $REAL_NODE"
   else
     echo "    (no node available, skipping the node leg)"
   fi


### PR DESCRIPTION
## What and why

Installed toolkit clones go stale because nobody runs `git pull`. This adds a `lib/auto-update.sh`
script that a Claude Code `SessionStart` hook runs once a day: it fetches, fast-forwards the clone
only when that's guaranteed safe, and replays whichever `install.sh` / `install-opinionated-rules.sh`
invocations it has on record, so added or removed skills and rules stay in sync too. Both installers
wire the hook up by default (with `--no-auto-update` / `--auto-update` to opt out or back in), and
none of this ever reaches the agent's context: only stuck states and errors get a user-visible
message.

## Decisions worth knowing

The pull is deliberately conservative: it only fast-forwards a clean clone on its default branch
with no diverged history, and it never deletes anything it didn't create itself. See the refuse
checks in `lib/auto-update.sh`.

Other agents (Gemini CLI, Copilot CLI, Cursor, OpenCode, plain cron/launchd) get documented recipes
in `docs/auto-update.md` rather than being wired up, since only Claude Code's own hook contract was
verified against its docs.

Two rounds of automated PR review turned up real concurrency and leak bugs that are worth knowing
about even though they're fixed now: two runs racing a stale lock could each think they owned it
(`lib/auto-update.sh:256`), a killed run could leave its `git fetch` running past the lock release
(`lib/auto-update.sh:215`), and a remote URL with embedded credentials could reach a user-facing
message (`lib/auto-update.sh:150`).

## Review guide

`lib/auto-update.sh` is where the judgment calls are: the lock/takeover logic, the signal handling
that has to kill an in-flight fetch's whole process tree, and the credential redaction, all landed
across two review rounds after the first versions had races. Worth reading closely.

`lib/install-utils.sh`'s `settings_merge` (three separate JSON engines: python, node, jq, which have
to agree) and `finish_auto_update` (the opt-out state machine and hook convergence) are the other
spot where a subtle bug hid: a failed marker write used to silently flip the opt-out decision instead
of just failing to persist it.

Everything else is mechanical: `install.sh` / `install-opinionated-rules.sh` just add the two flags
and call into `lib/install-utils.sh`, the docs changes are prose, and `test/auto-update/run.sh` is a
64-case harness that already passes end to end (`bash test/auto-update/run.sh`, both GNU bash and
macOS's `/bin/bash` 3.2).

## Known gaps

Windows: stock Git for Windows ships no `pkill`/`pgrep`, so the fetch-watchdog's process-tree kill
silently no-ops there. No regression (Windows never had this protection), just not fixed.

The installers' default target directory ignores `CLAUDE_CONFIG_DIR`, which predates this change and
wasn't in scope here, but it makes the new "not Claude Code's own dir" message read oddly for anyone
relying on that variable.

Several commit subjects on this branch (`chore: misc fixes`, `chore: address review comments`, …)
don't say what they contain, and were flagged as worth rewording at merge or squash time.
