### PR TITLE
fix(maintainer-review): let one line acknowledge what the author fixed

### DIFF
--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.3"
+  version: "0.4"
 ---
 
 # Maintainer review
@@ -124,8 +124,9 @@ reviewed, so say so rather than act. Drafting is not posting, and a request to a
 of the wording: show the text, then wait. Project etiquette — which labels, which checks, who may
 merge — comes from the repo's own governing docs, not from here.
 
-- **Comments** — the concern, the location, the suggested change, nothing else. No preamble, no
-  recap of the PR, no praise padding. Invoke
+- **Comments** — the concern, the location, the suggested change, and nothing else beyond one
+  opening line on the round's first comment, naming what the author fixed since the last round,
+  which is acknowledgment, not padding. No recap of the PR, no praise padding. Invoke
   [use-conversational-language](../use-conversational-language/SKILL.md) for the wording.
 - **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
 - **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees. The


### PR DESCRIPTION
Ran into this reviewing an AzerothCore PR. My comment draft read as an attack, and part of fixing it was opening with the fact that the author had cleared three blockers within hours. The Comments bullet in maintainer-review didn't allow that. It reads "the concern, the location, the suggested change, nothing else. No preamble, no recap of the PR, no praise padding", and nothing in it separates generic praise from a specific note on what the author fixed since the last round.

So the bullet now carves out exactly one line for that, on the round's first comment.

Two things worth knowing about the wording.

"No preamble" is gone. The bullet's force was always the exhaustive "nothing else", and the named bans were instances of it, so any other opener stays banned. Keeping "No preamble" would have contradicted the carve-out, since the line it permits is a preamble.

The per-round scoping is deliberate. The bullet governs each posted comment and a round usually produces several, so without it every comment in a round could open with an acknowledgment, which is the padding the same sentence bans.

I also tried a matching rule in use-conversational-language, about several asks in one comment reading as an attack however polite each one is, and dropped it. Every phrasing either duplicated the existing "soften asks, often a question even when sure the code is wrong" tip or contradicted "the ask alone is usually the whole comment". That file already covers the voice side. What was missing was only the content permission, and that belongs here.

Known gap: a round that ends in an approval still has nowhere for the acknowledgment, since approvals carry an empty body. That predates this change and isn't made worse by it.

Version goes to 0.4.
