### PR TITLE
fix(self-review): do not re-check in later rounds what was already checked

### DIFF
--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -177,8 +177,9 @@ the outcome — proof-of-process collapses.
 Compact above all: one line per finding, fusing location and concrete failure; the full prose stays
 in the session. The **Reviewed** line always carries the latest round's state (`working tree on
 <SHA>`, marked `unpinned`, when not a commit; once stamped, the new SHA with `stamped from <that
-state>`) and diffstat; **Diff** its full hash, for the Stamp; history lives in the round headings,
-each naming the state it reviewed and, after the first, its scope — full with its reason.
+state>`) and diffstat; **Diff** its full hash (never a later fix's), for the Stamp; history lives
+in the round headings, each naming the state it reviewed and, after the first, its scope — full
+with its reason.
 Provenance exactly as the environment reports it, `unknown` when it doesn't — never guessed or
 recalled; the reviewer's model, when it differs from the session's, appended to the **By** line as
 `review by <model>`; skill version from this file's frontmatter, date = today.

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -115,39 +115,42 @@ then the walk returns to that same finding, still open. Three dispositions close
 Never drop or soften a finding: every one appears in the report with its disposition. Dispositions
 carry forward across rounds: a re-raised finding matching a dismissed or deferred one keeps that
 disposition and is not re-walked; one matching a fixed finding means the fix didn't hold — reopen it
-and walk it again. The report lists each finding once, with its latest disposition.
+and walk it again, except an unapplied metadata draft: pending, not failed. The report lists each
+finding once, with its latest disposition.
 
-Done when every finding of the round is dispositioned and, after the last fix, the full diff
-hashed as in step 3.
+Done when every finding of the round is dispositioned and the full diff re-hashed as in step 3.
 
 ## Rounds
 
-Anything fixed → a fresh round on the new state — fixes are new unreviewed code; committing between
-rounds stays the author's move (propose a commit message in the repo's style), demanded only where
-project rules require a pinned review. The first round reviews the whole changeset; every later
-one, in this invocation or a re-run, only the **delta** — what changed since the last reviewed
-state — and its reach. The reviewer gets the full current diff as reference, plus:
+Anything fixed, or a file left uncovered, → a fresh round on the new state — fixes are new
+unreviewed code; a metadata draft earns one only once applied (below). Committing between rounds
+stays the author's move (propose a commit message in the repo's style), demanded only where project
+rules require a pinned review. The first round reviews the whole changeset; every later one, in
+this invocation or a re-run, only the **delta** — what changed since the last reviewed state — and
+its reach. The reviewer gets the full current diff as reference, plus:
 
 - the delta hunks — one the walk applied carries the failure it addressed, never its disposition;
   dismissed and deferred findings go unmentioned;
-- files the last round reported uncovered, added to the scope;
+- files the last round reported uncovered, reviewed whole as in a first round;
 - the mandate: check each hunk holds and follow its reach — call sites of what changed, mirrored
   sites, the tests and docs covering it, whatever else it judges reached; the rest of the changeset
   was reviewed and stands: no hunting there, though a grounded finding met on the way is reported
-  like any other; governing-docs checklist and leftovers hunt over the delta only.
+  like any other; governing-docs checklist and leftovers hunt over the delta and the uncovered
+  files only.
 
-The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied,
-when the full diff's hash taken after the last fix still matches at round start; else
-`git diff <SHA>` (a tip: `<SHA> <source>`), with step 3's pathspec, when the last reviewed state
-is a commit `<SHA>` whose merge base with the target is still `<base>`. Full also whenever the
-author asks or project rules require it. Submission metadata that changed since the last round —
-a fix the author applied, a new commit's subject — joins the delta as its re-read text, judged
-against the diff it describes; alone, it still earns a round.
+The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied —
+possibly none — when the hash the walk took still matches at round start; else `git diff <SHA>`
+(a tip: `<SHA> <source>`), with step 3's pathspec, when the last reviewed state is a commit
+`<SHA>` whose merge base with the target is still `<base>`. Full also whenever the author asks or
+project rules require it. Submission metadata that changed since the last round — a fix the
+author applied, a new commit's subject — joins the delta as its re-read text, judged against the
+diff it describes; alone, it still earns a round.
 
-Rounds stop when one yields nothing fixed — clean, or every new finding dismissed or deferred — or
-at the cap of 3 per invocation, there to bound cost; the author can stop earlier at any point, or
-explicitly ask for rounds beyond the cap. Every fix no later round covered leaves a "fixes not
-re-reviewed" caveat in the report.
+Rounds stop when one earns no fresh round — nothing uncovered, nothing fixed (clean, or every new
+finding dismissed, deferred or a draft still unapplied), no metadata changed — or at the cap of 3
+per invocation, there to bound cost; the author can stop earlier at any point, or explicitly ask
+for rounds beyond the cap. Every fix no later round covered — an unapplied draft included — leaves
+a "fixes not re-reviewed" caveat in the report naming it.
 
 Done when a stop condition has ended the rounds.
 
@@ -218,16 +221,16 @@ recalled; the reviewer's model, when it differs from the session's, appended to 
 
 Done when the report holds the outcome line, intent, changeset refs with diffstat, diff hash,
 provenance with skill version and date, rules-file status, and every round with its reviewed state,
-scope and dispositioned findings — each on its mandated side of the split.
+scope (after the first) and dispositioned findings — each on its mandated side of the split.
 
 ## Stamp
 
 Step 3's hash equal to the report's **Diff** → content unchanged (after committing the reviewed
-work, an amend, a rebase leaving the diff byte-identical): no round — unless the report lists a
-metadata fix not re-reviewed, then one on its re-read text alone; **Reviewed** line set to the
-current state — a tip → `stamped from <previous state>` replacing `unpinned` — then Wrap up.
-Different → say so, Review onward as a later round (Rounds). Done when the report carries the
-current state or Review has started.
+work, an amend, a rebase leaving the diff byte-identical): no round on it; **Reviewed** line set to
+the current state — a tip → `stamped from <previous state>` replacing `unpinned` — then, given a
+commit subject added since or a caveat naming a draft applied since or a file uncovered, Review
+onward as a later round on those alone (Rounds), else Wrap up. Different → say so, Review onward
+as a later round (Rounds). Done when the report carries the current state or Review has started.
 
 ## Wrap up
 
@@ -235,8 +238,9 @@ Print: the report's project-relative path, with the instruction to paste its con
 description or a comment; a warning not to commit the report — a later `git add .` drags it into
 the PR — unless the project rules file says otherwise; a reminder to run the project's usual
 checks (build, lint, tests) before pushing — this skill never runs them; and that the pushed head
-must match the reported SHA: unpinned → commit, then re-invoke to stamp; any later commit → the
-same re-invocation, a stamp when the content held, else a re-run. Done when all four are printed.
+must match the reported SHA: unpinned → commit, then re-invoke to stamp; any later commit or
+applied draft → the same re-invocation: a stamp when the content held, its new metadata reviewed
+alone, else a re-run. Done when all four are printed.
 
 ## Boundaries
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -78,9 +78,9 @@ it runs without its confirmation step — with:
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
   as a checklist, not as background reading, against every changed file and the submission itself,
-  whose metadata the prompt must carry (commit subjects, and any PR title, description, linked
-  issues); and leftovers — debug prints, commented-out code, stray TODOs, accidentally committed
-  files;
+  whose metadata the prompt must carry (commit subjects `<base>..<source>`, then any PR title,
+  description, linked issues — hashed in that order, as read, like the diff, for the report); and
+  leftovers — debug prints, commented-out code, stray TODOs, accidentally committed files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it
@@ -142,7 +142,7 @@ The delta must be exact, else the round runs full, saying why. Exact: the fixes 
 possibly none — when the hash the walk took still matches at round start; else `git diff <SHA>`
 (a tip: `<SHA> <source>`), with step 3's pathspec, when the last reviewed state is a commit
 `<SHA>` whose merge base with the target is still `<base>`. Full also whenever the author asks or
-project rules require it. Submission metadata that changed since the last round — a fix the
+project rules require it. Submission metadata whose hash changed since the last round — a fix the
 author applied, a new commit's subject — joins the delta as its re-read text, judged against the
 diff it describes; alone, it still earns a round.
 
@@ -170,19 +170,19 @@ Two parts — maintainers drown in AI-generated review walls, so the visible par
 Visible, each line its own paragraph (blank lines between, no blockquote): the heading, **Outcome**,
 outcome-weakening caveats, **Reviewed**, **By**, verification evidence (e.g. testing performed).
 Everything else collapses into `<details>`, in order: **Intent**, **Project rules**, **Diff**,
-procedural caveats, the rounds; the blank line after `</summary>` is required — without it the
-markdown inside won't render. Placement, unless project rules explicitly override: a caveat is
-visible iff it weakens what **Outcome** claims (fixes not re-reviewed, incomplete coverage naming
-the unreviewed files, a same-context fallback), procedural confirmations (e.g. files confirmed
-local-only) collapse; any other line is visible iff it records verification performed or qualifies
-the outcome — proof-of-process collapses.
+**Metadata**, procedural caveats, the rounds; the blank line after `</summary>` is required —
+without it the markdown inside won't render. Placement, unless project rules explicitly override:
+a caveat is visible iff it weakens what **Outcome** claims (fixes not re-reviewed, incomplete
+coverage naming the unreviewed files, a same-context fallback), procedural confirmations (e.g.
+files confirmed local-only) collapse; any other line is visible iff it records verification
+performed or qualifies the outcome — proof-of-process collapses.
 
 Compact above all: one line per finding, fusing location and concrete failure; the full prose stays
 in the session. The **Reviewed** line always carries the latest round's state (`working tree on
 <SHA>`, marked `unpinned`, when not a commit; once stamped, the new SHA with `stamped from <that
-state>`) and diffstat; **Diff** its full hash (never a later fix's), for the Stamp; history lives
-in the round headings, each naming the state it reviewed and, after the first, its scope — full
-with its reason.
+state>`) and diffstat; **Diff** and **Metadata** their full hashes (never a later fix's), for the
+Stamp; history lives in the round headings, each naming the state it reviewed and, after the
+first, its scope — full with its reason.
 Provenance exactly as the environment reports it, `unknown` when it doesn't — never guessed or
 recalled; the reviewer's model, when it differs from the session's, appended to the **By** line as
 `review by <model>`; skill version from this file's frontmatter, date = today.
@@ -205,6 +205,8 @@ recalled; the reviewer's model, when it differs from the session's, appended to 
 
 **Diff** `9f2c1e0b7d3a4c5e6f718293a4b5c6d7e8f90123`
 
+**Metadata** `4d5e6f718293a4b5c6d7e8f901239f2c1e0b7d3a`
+
 ## Round 1 — `abc1234`, 4 findings
 
 1. `src/foo.c:142` — null deref when the timer expires mid-update → **fixed**
@@ -219,18 +221,19 @@ recalled; the reviewer's model, when it differs from the session's, appended to 
 </details>
 ```
 
-Done when the report holds the outcome line, intent, changeset refs with diffstat, diff hash,
-provenance with skill version and date, rules-file status, and every round with its reviewed state,
-scope (after the first) and dispositioned findings — each on its mandated side of the split.
+Done when the report holds the outcome line, intent, changeset refs with diffstat, diff and
+metadata hashes, provenance with skill version and date, rules-file status, and every round with
+its reviewed state, scope (after the first) and dispositioned findings — each on its mandated side
+of the split.
 
 ## Stamp
 
 Step 3's hash equal to the report's **Diff** → content unchanged (after committing the reviewed
 work, an amend, a rebase leaving the diff byte-identical): no round on it; **Reviewed** line set to
 the current state — a tip → `stamped from <previous state>` replacing `unpinned` — then, given a
-commit subject added since or a caveat naming a draft applied since or a file uncovered, Review
-onward as a later round on those alone (Rounds), else Wrap up. Different → say so, Review onward
-as a later round (Rounds). Done when the report carries the current state or Review has started.
+metadata hash differing from the report's or a caveat naming a file uncovered, Review onward as a
+later round on those alone (Rounds), else Wrap up. Different → say so, Review onward as a later
+round (Rounds). Done when the report carries the current state or Review has started.
 
 ## Wrap up
 
@@ -239,8 +242,8 @@ description or a comment; a warning not to commit the report — a later `git ad
 the PR — unless the project rules file says otherwise; a reminder to run the project's usual
 checks (build, lint, tests) before pushing — this skill never runs them; and that the pushed head
 must match the reported SHA: unpinned → commit, then re-invoke to stamp; any later commit or
-applied draft → the same re-invocation: a stamp when the content held, its new metadata reviewed
-alone, else a re-run. Done when all four are printed.
+metadata edit → the same re-invocation: a stamp when the content held, its changed metadata
+reviewed alone, else a re-run. Done when all four are printed.
 
 ## Boundaries
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -78,9 +78,10 @@ it runs without its confirmation step — with:
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
   as a checklist, not as background reading, against every changed file and the submission itself,
-  whose metadata the prompt must carry (commit subjects `<base>..<source>`, then any PR title,
-  description, linked issues — hashed in that order, as read, like the diff, for the report); and
-  leftovers — debug prints, commented-out code, stray TODOs, accidentally committed files;
+  whose metadata the prompt must carry (commit subjects, `git log --format=%s <base>..<source>`,
+  then any PR title, description, linked issues, verbatim — hashed in that order like the diff,
+  for the report); and leftovers — debug prints, commented-out code, stray TODOs, accidentally
+  committed files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it
@@ -139,12 +140,12 @@ its reach. The reviewer gets the full current diff as reference, plus:
   files only.
 
 The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied —
-possibly none — when the hash the walk took still matches at round start; else `git diff <SHA>`
-(a tip: `<SHA> <source>`), with step 3's pathspec, when the last reviewed state is a commit
-`<SHA>` whose merge base with the target is still `<base>`. Full also whenever the author asks or
-project rules require it. Submission metadata whose hash changed since the last round — a fix the
-author applied, a new commit's subject — joins the delta as its re-read text, judged against the
-diff it describes; alone, it still earns a round.
+possibly none — when the hash the walk took (at a Stamp, the report's **Diff**) still matches at
+round start; else `git diff <SHA>` (a tip: `<SHA> <source>`), with step 3's pathspec, when the
+last reviewed state is a commit `<SHA>` whose merge base with the target is still `<base>`. Full
+also whenever the author asks or project rules require it. Submission metadata whose hash changed
+since the last round — a fix the author applied, a new commit's subject — joins the delta as its
+re-read text, judged against the diff it describes; alone, it still earns a round.
 
 Rounds stop when one earns no fresh round — nothing uncovered, nothing fixed (clean, or every new
 finding dismissed, deferred or a draft still unapplied), no metadata changed — or at the cap of 3

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -50,9 +50,9 @@ blindness, so someone else's PR has nothing to escape and belongs to `maintainer
 4. Assemble the submission metadata as one block, hashed like the diff: the lines `subjects:`,
    `title:`, `body:`, `issues:` in that order, each followed by its value's lines verbatim —
    subjects from `git log --format=%s <base>..<source>`; from the target forge's open PR of source
-   into target, its title, description and the issue ids it lists as linked (bare numbers
-   ascending, one per line); nothing under a label without a value (e.g. no PR yet) — every line
-   LF-terminated, CRLF folded to LF, trailing blank lines dropped.
+   into target, its title, description and the issue ids it lists as linked (as the forge shows
+   them, sorted, one per line); nothing under a label without a value (e.g. no PR yet) — every
+   line LF-terminated, CRLF folded to LF, each value's trailing blank lines dropped.
 
 Done when source branch, target, reviewed state (SHA, or working tree on SHA), the diff's hash
 (`git diff … | git hash-object --stdin`) and the metadata's are recorded and the diff is non-empty.
@@ -145,13 +145,13 @@ its reach. The reviewer gets the full current diff as reference, plus:
   files only.
 
 The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied —
-possibly none — when the diff hash the walk took still matches at round start, or none when Stamp
-found **Diff** equal; else `git diff <SHA>` (a tip: `<SHA> <source>`), with step 2's exclusions,
-when the last reviewed state is a commit `<SHA>` whose merge base with the target is still
-`<base>`. Full also whenever the author asks or project rules require it. Submission metadata whose
-hash differs from the last round's (none recorded → differs) — a fix the author applied, a new
-commit's subject — joins the delta as its re-read text, judged against the diff it describes;
-alone, it still earns a round.
+possibly none — when the diff hash the walk took still matches at round start, or none in the
+round a Stamp with **Diff** equal orders; else `git diff <SHA>` (a tip: `<SHA> <source>`), with
+step 2's exclusions, when the last reviewed state is a commit `<SHA>` whose merge base with the
+target is still `<base>`. Full also whenever the author asks or project rules require it.
+Submission metadata whose hash differs from the last round's (none recorded → differs) — a fix the
+author applied, a new commit's subject — joins the delta as its re-read text, judged against the
+diff it describes; alone, it still earns a round.
 
 Rounds stop when one earns no fresh round — nothing uncovered, nothing fixed (clean, or every new
 finding dismissed, deferred or a draft still unapplied), no metadata changed — or at the cap of 3

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 type: flow
 license: MIT
 metadata:
-  version: "0.7"
+  version: "0.8"
 ---
 
 # Self-review
@@ -54,17 +54,18 @@ hash (`git diff … | git hash-object --stdin`) are recorded and the diff is non
 ## Project rules file
 
 `.agents/docs/self-review-rules.md`, when the project carries one, adds project-specific rules or
-overrides to the review mandate and process (extra focus areas, round cap, report handling, a pinned
-review required — modified tracked files then block every round, fixes committed before the next) —
-never to the Boundaries below. Absent → skip silently. Either way, the report states whether it was
-found and applied.
+overrides to the review mandate and process (extra focus areas, round cap, full rounds only, report
+handling, a pinned review required — modified tracked files then block every round, fixes committed
+before the next) — never to the Boundaries below. Absent → skip silently. Either way, the report
+states whether it was found and applied.
 
 ## Review
 
 A report already present → Stamp (below) first.
 
-Load and follow [fresh-eyes-review](../fresh-eyes-review/SKILL.md) on the reviewed state —
-inputs all explicit, so it runs without its confirmation step — with:
+Load and follow [fresh-eyes-review](../fresh-eyes-review/SKILL.md) on the reviewed state — whole
+in a changeset's first round, narrowed per Rounds below in any later one — inputs all explicit, so
+it runs without its confirmation step — with:
 
 - an intent statement — one or two sentences distilled from the task's ticket or requirements
   when the planning home holds them, never the document itself (it carries the author rationale
@@ -83,7 +84,7 @@ inputs all explicit, so it runs without its confirmation step — with:
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it
-  covered every changed file — naming any it didn't.
+  covered every changed file in its scope — naming any it didn't.
 
 Done when the reviewer has returned its findings — possibly none — its provenance, and its
 coverage.
@@ -100,7 +101,9 @@ escape hatch. Anything the author says that isn't a disposition is discussion, n
 answer the question, check the code, revise the recommendation, do what they ask with the finding —
 then the walk returns to that same finding, still open. Three dispositions close one:
 
-- **fix** — apply it to the working tree now; committing stays the author's move.
+- **fix** — apply it to the working tree now; committing stays the author's move. Submission
+  metadata (PR title, description, commit subjects) the agent only drafts — applying it is the
+  author's (Boundaries).
 - **dismiss** — record the author's reason, pushing once toward one a maintainer can evaluate
   ("the caller already null-checks", not "disagree"); "mirrors the existing pattern" counts only
   once that pattern is verified sound — an unchecked one ratifies its bugs; if the author
@@ -109,18 +112,44 @@ then the walk returns to that same finding, still open. Three dispositions close
   another PR, a note the author keeps. Record the destination in one line; drafting the text is
   in scope, filing or posting it is not (Boundaries).
 
-Never drop or soften a finding: every one appears in the report with its disposition. Anything fixed
-→ a fresh round runs on the new state — fixes are new unreviewed code; committing between rounds
-stays the author's move (propose a commit message in the repo's style), demanded only where project
-rules require a pinned review. Rounds stop when one yields nothing fixed — clean, or every new
-finding dismissed or deferred — or at the cap of 3 rounds per invocation, there to bound cost; the
-author can stop earlier at any point, or explicitly ask for rounds beyond the cap. Every fix no
-later round covered leaves a "fixes not re-reviewed" caveat in the report. Dispositions carry
-forward across rounds: a re-raised finding matching a dismissed or deferred one keeps that
+Never drop or soften a finding: every one appears in the report with its disposition. Dispositions
+carry forward across rounds: a re-raised finding matching a dismissed or deferred one keeps that
 disposition and is not re-walked; one matching a fixed finding means the fix didn't hold — reopen it
 and walk it again. The report lists each finding once, with its latest disposition.
 
-Done when every finding is dispositioned and a stop condition has ended the rounds.
+Done when every finding of the round is dispositioned and, after the last fix, the full diff
+hashed as in step 3.
+
+## Rounds
+
+Anything fixed → a fresh round on the new state — fixes are new unreviewed code; committing between
+rounds stays the author's move (propose a commit message in the repo's style), demanded only where
+project rules require a pinned review. The first round reviews the whole changeset; every later
+one, in this invocation or a re-run, only the **delta** — what changed since the last reviewed
+state — and its reach. The reviewer gets the full current diff as reference, plus:
+
+- the delta hunks — one the walk applied carries the failure it addressed, never its disposition;
+  dismissed and deferred findings go unmentioned;
+- files the last round reported uncovered, added to the scope;
+- the mandate: check each hunk holds and follow its reach — call sites of what changed, mirrored
+  sites, the tests and docs covering it, whatever else it judges reached; the rest of the changeset
+  was reviewed and stands: no hunting there, though a grounded finding met on the way is reported
+  like any other; governing-docs checklist and leftovers hunt over the delta only.
+
+The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied,
+when the full diff's hash taken after the last fix still matches at round start; else
+`git diff <SHA>` (a tip: `<SHA> <source>`), with step 3's pathspec, when the last reviewed state
+is a commit `<SHA>` whose merge base with the target is still `<base>`. Full also whenever the
+author asks or project rules require it. Submission metadata that changed since the last round —
+a fix the author applied, a new commit's subject — joins the delta as its re-read text, judged
+against the diff it describes; alone, it still earns a round.
+
+Rounds stop when one yields nothing fixed — clean, or every new finding dismissed or deferred — or
+at the cap of 3 per invocation, there to bound cost; the author can stop earlier at any point, or
+explicitly ask for rounds beyond the cap. Every fix no later round covered leaves a "fixes not
+re-reviewed" caveat in the report.
+
+Done when a stop condition has ended the rounds.
 
 ## Report
 
@@ -149,10 +178,10 @@ Compact above all: one line per finding, fusing location and concrete failure; t
 in the session. The **Reviewed** line always carries the latest round's state (`working tree on
 <SHA>`, marked `unpinned`, when not a commit; once stamped, the new SHA with `stamped from <that
 state>`) and diffstat; **Diff** its full hash, for the Stamp; history lives in the round headings,
-each naming the state it reviewed. Provenance exactly as the environment reports it, `unknown` when
-it doesn't — never guessed or recalled; the reviewer's model, when it differs from the session's,
-appended to the **By** line as `review by <model>`; skill version from this file's frontmatter,
-date = today.
+each naming the state it reviewed and, after the first, its scope — full with its reason.
+Provenance exactly as the environment reports it, `unknown` when it doesn't — never guessed or
+recalled; the reviewer's model, when it differs from the session's, appended to the **By** line as
+`review by <model>`; skill version from this file's frontmatter, date = today.
 
 ```markdown
 # Self-review — my-feature → main
@@ -181,22 +210,23 @@ date = today.
 4. `src/foo.c:97` — guard duplicates the check 4 lines up → **dismissed**: mirrors the pattern in
    this file, checked sound at :61 and :88; refactor out of scope
 
-## Round 2 — `def5678`, clean
+## Round 2 — `def5678`, round 1 fixes, clean
 
 </details>
 ```
 
 Done when the report holds the outcome line, intent, changeset refs with diffstat, diff hash,
-provenance with skill version and date, rules-file status, and every round with its reviewed state
-and dispositioned findings — each on its mandated side of the split.
+provenance with skill version and date, rules-file status, and every round with its reviewed state,
+scope and dispositioned findings — each on its mandated side of the split.
 
 ## Stamp
 
 Step 3's hash equal to the report's **Diff** → content unchanged (after committing the reviewed
-work, an amend, a rebase leaving the diff byte-identical): no round; **Reviewed** line set to the
+work, an amend, a rebase leaving the diff byte-identical): no round — unless the report lists a
+metadata fix not re-reviewed, then one on its re-read text alone; **Reviewed** line set to the
 current state — a tip → `stamped from <previous state>` replacing `unpinned` — then Wrap up.
-Different → say so, Review onward. Done when the report carries the current state or Review has
-started.
+Different → say so, Review onward as a later round (Rounds). Done when the report carries the
+current state or Review has started.
 
 ## Wrap up
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -47,9 +47,15 @@ blindness, so someone else's PR has nothing to escape and belongs to `maintainer
    commits as the author's. Empty diff → probably a wrong target (typical: a fork's default
    branch already holding the commits) — say so and ask for the true one; it needs no local
    ref, `git fetch <url> <branch>` works by URL.
+4. Assemble the submission metadata as one block, hashed like the diff: the lines `subjects:`,
+   `title:`, `body:`, `issues:` in that order, each followed by its value's lines verbatim —
+   subjects from `git log --format=%s <base>..<source>`; from the target forge's open PR of source
+   into target, its title, description and the issue ids it lists as linked (bare numbers
+   ascending, one per line); nothing under a label without a value (e.g. no PR yet) — every line
+   LF-terminated, CRLF folded to LF, trailing blank lines dropped.
 
-Done when source branch, target, reviewed state (SHA, or working tree on SHA) and the diff's
-hash (`git diff … | git hash-object --stdin`) are recorded and the diff is non-empty.
+Done when source branch, target, reviewed state (SHA, or working tree on SHA), the diff's hash
+(`git diff … | git hash-object --stdin`) and the metadata's are recorded and the diff is non-empty.
 
 ## Project rules file
 
@@ -78,10 +84,7 @@ it runs without its confirmation step — with:
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
   as a checklist, not as background reading, against every changed file and the submission itself,
-  whose metadata the prompt must carry verbatim (commit subjects,
-  `git log --format=%s <base>..<source>`, then any PR title, description and sorted linked-issue
-  ids — and, for the report, hashed like the diff as one block, each field under its own
-  `subjects:`/`title:`/`body:`/`issues:` line, empty when absent); and leftovers — debug prints,
+  whose metadata block (step 4) the prompt must carry verbatim; and leftovers — debug prints,
   commented-out code, stray TODOs, accidentally committed files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
@@ -120,7 +123,8 @@ disposition and is not re-walked; one matching a fixed finding means the fix did
 and walk it again, except an unapplied metadata draft: pending, not failed. The report lists each
 finding once, with its latest disposition.
 
-Done when every finding of the round is dispositioned and the full diff re-hashed as in step 3.
+Done when every finding of the round is dispositioned and diff and metadata re-hashed as in steps
+3 and 4.
 
 ## Rounds
 
@@ -141,12 +145,13 @@ its reach. The reviewer gets the full current diff as reference, plus:
   files only.
 
 The delta must be exact, else the round runs full, saying why. Exact: the fixes the walk applied —
-possibly none — when the hash the walk took (at a Stamp, the report's **Diff**) still matches at
-round start; else `git diff <SHA>` (a tip: `<SHA> <source>`), with step 3's pathspec, when the
-last reviewed state is a commit `<SHA>` whose merge base with the target is still `<base>`. Full
-also whenever the author asks or project rules require it. Submission metadata whose hash changed
-since the last round — a fix the author applied, a new commit's subject — joins the delta as its
-re-read text, judged against the diff it describes; alone, it still earns a round.
+possibly none — when the diff hash the walk took still matches at round start, or none when Stamp
+found **Diff** equal; else `git diff <SHA>` (a tip: `<SHA> <source>`), with step 2's exclusions,
+when the last reviewed state is a commit `<SHA>` whose merge base with the target is still
+`<base>`. Full also whenever the author asks or project rules require it. Submission metadata whose
+hash differs from the last round's (none recorded → differs) — a fix the author applied, a new
+commit's subject — joins the delta as its re-read text, judged against the diff it describes;
+alone, it still earns a round.
 
 Rounds stop when one earns no fresh round — nothing uncovered, nothing fixed (clean, or every new
 finding dismissed, deferred or a draft still unapplied), no metadata changed — or at the cap of 3
@@ -232,10 +237,10 @@ of the split.
 
 Step 3's hash equal to the report's **Diff** → content unchanged (after committing the reviewed
 work, an amend, a rebase leaving the diff byte-identical): no round on it; **Reviewed** line set to
-the current state — a tip → `stamped from <previous state>` replacing `unpinned` — then, given a
-metadata hash differing from the report's or a caveat naming a file uncovered, Review onward as a
-later round on those alone (Rounds), else Wrap up. Different → say so, Review onward as a later
-round (Rounds). Done when the report carries the current state or Review has started.
+the current state — a tip → `stamped from <previous state>` replacing `unpinned` — then, given
+changed metadata (Rounds) or a caveat naming a file uncovered, Review onward as a later round on
+those alone, else Wrap up. Different → say so, Review onward as a later round (Rounds). Done when
+the report carries the current state or Review has started.
 
 ## Wrap up
 

--- a/skills/self-review/SKILL.md
+++ b/skills/self-review/SKILL.md
@@ -78,10 +78,11 @@ it runs without its confirmation step — with:
 - the mandate framed as a maintainer's merge gate — would anything here block the merge? — and
   extended by: the project's own governing docs (contributing, agent instructions, codestyle) run
   as a checklist, not as background reading, against every changed file and the submission itself,
-  whose metadata the prompt must carry (commit subjects, `git log --format=%s <base>..<source>`,
-  then any PR title, description, linked issues, verbatim — hashed in that order like the diff,
-  for the report); and leftovers — debug prints, commented-out code, stray TODOs, accidentally
-  committed files;
+  whose metadata the prompt must carry verbatim (commit subjects,
+  `git log --format=%s <base>..<source>`, then any PR title, description and sorted linked-issue
+  ids — and, for the report, hashed like the diff as one block, each field under its own
+  `subjects:`/`title:`/`body:`/`issues:` line, empty when absent); and leftovers — debug prints,
+  commented-out code, stray TODOs, accidentally committed files;
 - the grounded bar: a finding exists only with a nameable concrete failure, violated rule, or
   redundancy — hedged speculation is out, zero findings is a valid outcome;
 - an instruction to the reviewer to report back the harness and model it ran on, and whether it


### PR DESCRIPTION
# `/self-review`: later rounds only look at what changed

## What and why

The first review round still covers the whole changeset. Every round after it now looks only at what changed since the last reviewed state, plus whatever that reaches (call sites, mirrored spots, tests and docs).

Re-reviewing everything each round was expensive for code that had already been cleared, and it kept dragging back points the walk had settled.

## Decisions worth knowing

Rounds now have their own section, split out of the disposition walk. The walk finishes one round's findings, the new section owns the loop and the stop conditions. See "Disposition walk" and "Rounds" in `skills/self-review/SKILL.md`.

A narrow round only happens when the delta can be derived exactly: the walk re-hashes the full diff at its end and that hash still matches when the next round starts, or the last reviewed state is a commit whose merge base hasn't moved. Anything else falls back to a full round and the report says why.

The fix hunks handed to a later round carry the failure each one addressed and nothing else: no disposition, and dismissed or deferred findings aren't mentioned. That's a deliberate exception to keeping past dispositions away from the reviewer, a fix can't be judged without knowing what it was for.

The report's **Diff** line keeps the hash of the state the last round reviewed, never one taken after a later fix. Otherwise a re-invocation after committing unreviewed fixes would find the hashes equal and stamp them as reviewed.

The review now also hashes the submission metadata it read (commit subjects, then PR title, description and linked issues) and the report records it as a **Metadata** line next to **Diff**. The block has one fixed byte layout (four labels on their own lines, values verbatim under them, LF endings, bare issue numbers ascending), so two sessions hash unchanged metadata the same way. It's taken right after the diff hash and re-taken at the end of every walk, so a commit or an applied draft mid-session earns its round in that session, not the next.

Any metadata change since the last round, a draft the author applied, a new or reworded commit subject, a hand-edited description, joins the delta as its re-read text and on its own is enough to earn a round. Without the recorded hash a fresh session couldn't tell that anything changed.

One consequence worth knowing: committing to pin an unpinned review adds a commit subject, so the re-invocation stamps the diff and then runs a narrow round on that subject alone. It's a bounded read, the reviewer gets the diff as reference plus the new subject and doesn't hunt. We took that over skipping subjects, since a subject that misdescribes the change is a merge gate finding in repos that don't squash.

Metadata fixes are drafted only, never applied by the agent, which is what Boundaries already said about PR operations. A draft the author hasn't applied yet doesn't earn a round, and if the reviewer raises the point again it's pending, not a failed fix. It stays named in the "fixes not re-reviewed" caveat until then.

A file the reviewer says it didn't cover also earns the next round on its own and gets reviewed whole there, as in a first round, checklist and leftovers hunt included.

That gives "Stamp" a new case: an unchanged diff still runs a narrow round when the metadata hash differs from the report's or the caveat names an uncovered file. A report written by an older version has no **Metadata** line, which counts as differing.

Projects that don't want any of this can pin full rounds through `.agents/docs/self-review-rules.md`, and round headings in the report now carry their scope so a maintainer can see which ones were narrow.

## Review guide

"Rounds" is the new section and holds most of the judgment: what the reviewer is handed, how far "reach" is meant to go, how strict the exactness test should be before trusting a delta, and what earns or ends a round.

"Stamp" and the last sentence of "Wrap up" are worth a second read, they decide when an equal hash still gets a round. The metadata block is defined in step 4 of "Resolve the changeset", check that a fresh session can reproduce it byte for byte.

The rest is mechanical: version bump to 0.8, the scope wording in the report example, "every changed file in its scope" in the reviewer instructions.

## Known gaps

The narrowing leans on the reviewer following a fix's reach on its own. A fix that breaks something outside what it judges reached now slips through, where a full round would have caught it.

Fixes left unreviewed on an unpinned state can't be narrowed on a re-invocation, since the walk's hash isn't in the report. That path runs a full round.
