### PR TITLE
fix(handover): add 'Known Gaps' section only when it makes sense + do not assume facts

### DIFF
--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -3,7 +3,7 @@ name: handover
 description: Use when handing finished work over to code review — writing a PR description or packaging a change for review by a human, an agent, or both.
 license: MIT
 metadata:
-  version: "0.5"
+  version: "0.6"
 ---
 
 # Handover
@@ -45,13 +45,14 @@ Then match the plan's steps and acceptance criteria against the diff both ways �
 absent, present but unplanned. Done when every source is read or confirmed absent and every planned
 item is matched.
 
-## Never invent rationale
+## Source every claim
 
-State a "why" only where a source gives it. A deviation nothing explains is asked of the author
-once; unanswered or unaskable, it ships flagged in plain words ("nothing records why — worth
-confirming"), since it may be an unintentional gap rather than a decision. Sourcing is your gate,
-not the reviewer's reading: it decides what you may write, and never appears in the text.
-When not sure, always ask. Never guess.
+State a "why", or any other claim about the change, only where a source gives it. Silence is not a
+source: never infer a fact from what the diff and docs leave unsaid ("untested so far", "nobody
+calls this"). A deviation nothing explains is asked of the author once; unanswered or unaskable, it
+ships flagged in plain words ("nothing records why — worth confirming"), since it may be an
+unintentional gap rather than a decision. Sourcing is your gate, not the reviewer's reading: it
+decides what you may write, and never appears in the text. When not sure, always ask. Never guess.
 
 ## The artifact
 
@@ -78,10 +79,11 @@ Sections, skipped only when truly empty:
 2. **Decisions worth knowing** — at most 5 lines, each: what was chosen or what departs from the
    plan, its why or the missing-why flag, and where in the code to see it.
 3. **Review guide** — the few files where judgment matters and why; the rest named as mechanical.
-4. **Known gaps** — at most 3: shortcomings, assumptions, open questions.
+4. **Known gaps** — at most 3 shortcomings, assumptions or open questions the sources establish;
+   none → omit the section, never manufacture one.
 
-Done when every section is filled or knowingly skipped, nothing reads as verified that wasn't, and
-nothing in the text points at something the reviewer cannot open.
+Done when every section is filled or knowingly skipped, every claim traces to a source, and nothing
+in the text points at something the reviewer cannot open.
 
 ## Boundaries
 


### PR DESCRIPTION
I noticed 2 issues that I'm fixing in this PR:

1)Sometimes the "Known gaps" section does not make much sense, and it feels like it was generated just because.
2) It often makes assumptions, especially about testing: "Untested on a real changeset so far", when it should rather ask what has been tested and what has not.