### PR TITLE
feat(install): let a skill be excluded from installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ On Claude Code the install also registers a hook that runs that update for you o
 install made before it needs the command above once to pick it up
 ([docs/auto-update.md](./docs/auto-update.md)).
 
+Every skill is installed by default. To leave one out, name it once and the choice sticks, daily
+update included:
+
+```sh
+./install.sh --exclude use-conversational-language
+```
+
+`--include <name>` puts it back. Both are repeatable.
+
 On Windows the skills link through junctions, so the update command above works as-is, though an
 install predating them needs one `./install.sh --force` to convert. The rules are copied instead
 and need `--force` every time (see [Windows](./docs/install-skills.md#windows)).

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,8 @@
 #   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
 #   --skills-dir DIR   Agent's skills directory  (default: ~/.claude/skills)
 #   --force            Overwrite real files/dirs and foreign symlinks
+#   --exclude NAME     Skip this skill and remove our link to it (persists)
+#   --include NAME     Install it again after --exclude
 #   --no-auto-update   Do not register the daily self-update hook (persists)
 #   --auto-update      Register it again after --no-auto-update
 #   -h, --help         Show this help
@@ -46,6 +48,8 @@ FORCE=0
 AUTO_UPDATE=""
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 TARGET_FLAG=--skills-dir
+EXCLUDE_ADD=()
+EXCLUDE_DEL=()
 
 usage() {
   cat <<'EOF'
@@ -75,9 +79,15 @@ Options:
   --agents-dir DIR   Agent-neutral directory   (default: ~/.agents)
   --skills-dir DIR   Agent's skills directory  (default: ~/.claude/skills)
   --force            Overwrite real files/dirs and foreign symlinks
+  --exclude NAME     Skip this skill and remove our link to it (persists)
+  --include NAME     Install it again after --exclude
   --no-auto-update   Do not register the daily self-update hook (persists)
   --auto-update      Register it again after --no-auto-update
   -h, --help         Show this help
+
+Every skill is installed by default. --exclude is repeatable and is
+remembered in <agents-dir>/excluded-skills, so the daily self-update honours
+it instead of putting the skill back.
 
 When Claude Code is detected, this also registers a hook that fast-forwards
 this clone once a day and re-runs the installers: docs/auto-update.md.
@@ -95,6 +105,8 @@ while [ $# -gt 0 ]; do
       echo "install.sh installs skills only; for the rules run ./install-opinionated-rules.sh instead." >&2
       exit 1 ;;
     --force) FORCE=1; shift ;;
+    --exclude) EXCLUDE_ADD+=("$2"); shift 2 ;;
+    --include) EXCLUDE_DEL+=("$2"); shift 2 ;;
     --no-auto-update) AUTO_UPDATE=off; shift ;;
     --auto-update) AUTO_UPDATE=on; shift ;;
     -h|--help) usage 0 ;;
@@ -103,6 +115,15 @@ while [ $# -gt 0 ]; do
 done
 
 resolve_agents_dir
+load_exclusions excluded-skills
+for name in ${EXCLUDE_ADD[@]+"${EXCLUDE_ADD[@]}"}; do
+  [ -d "${REPO_DIR}/skills/${name}" ] || echo "Note: no skill named ${name} in this repo; excluding it anyway." >&2
+  exclude_add "$name"
+done
+for name in ${EXCLUDE_DEL[@]+"${EXCLUDE_DEL[@]}"}; do
+  exclude_remove "$name"
+done
+save_exclusions || echo "Warning: could not write ${EXCLUDE_FILE}; the exclusions apply to this run only." >&2
 
 # Phase 1: populate the agent-neutral dir with links into the repo.
 # Pruning the agents dir first breaks downstream agent links for removed
@@ -113,6 +134,10 @@ prune_dir "${AGENTS_DIR}/skills"
 begin_phase
 for skill in "${REPO_DIR}"/skills/*/; do
   [ -d "$skill" ] || continue
+  if is_excluded "$(basename "${skill%/}")"; then
+    unlink_one "$(basename "${skill%/}")" "${AGENTS_DIR}/skills"
+    continue
+  fi
   link_one "${skill%/}" "${AGENTS_DIR}/skills"
 done
 end_phase
@@ -128,10 +153,18 @@ TARGET_DIR="$(cd "$SKILLS_DIR" && pwd -P)"
 if [ "$TARGET_DIR" = "${AGENTS_DIR}/skills" ]; then
   echo "  ok     (this is the agents dir itself; already populated)"
 else
+  # Excluded entries go first: phase 1 removed what they point at, so leaving
+  # them to prune_dir would report them as pruned rather than as excluded.
+  for skill in "${REPO_DIR}"/skills/*/; do
+    [ -d "$skill" ] || continue
+    is_excluded "$(basename "${skill%/}")" || continue
+    unlink_one "$(basename "${skill%/}")" "$SKILLS_DIR"
+  done
   prune_dir "$SKILLS_DIR"
   begin_phase
   for skill in "${REPO_DIR}"/skills/*/; do
     [ -d "$skill" ] || continue
+    is_excluded "$(basename "${skill%/}")" && continue
     src="${AGENTS_DIR}/skills/$(basename "${skill%/}")"
     if [ ! -e "$src" ]; then
       count_skip

--- a/lib/install-utils.sh
+++ b/lib/install-utils.sh
@@ -99,6 +99,68 @@ is_ours() {
     || "$target" == "${AGENTS_DIR}"/* ]]
 }
 
+# Names the user does not want installed, one per line in ${AGENTS_DIR}/$1.
+# Deliberately not part of the invocation record: the auto-update replay
+# re-runs an installer with --agents-dir and its target flag only, so the
+# choice has to live where the replay finds it on its own.
+EXCLUDE_FILE=""
+EXCLUDED=""
+
+load_exclusions() {
+  local line
+  EXCLUDE_FILE="${AGENTS_DIR}/$1"
+  EXCLUDED=""
+  [ -f "$EXCLUDE_FILE" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    EXCLUDED="${EXCLUDED}${line}"$'\n'
+  done <"$EXCLUDE_FILE"
+}
+
+is_excluded() {
+  case $'\n'"$EXCLUDED" in
+    *$'\n'"$1"$'\n'*) return 0 ;;
+  esac
+  return 1
+}
+
+exclude_add() {
+  if ! is_excluded "$1"; then
+    EXCLUDED="${EXCLUDED}$1"$'\n'
+  fi
+}
+
+exclude_remove() {
+  local kept="" line
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    [ "$line" = "$1" ] && continue
+    kept="${kept}${line}"$'\n'
+  done <<<"$EXCLUDED"
+  EXCLUDED="$kept"
+}
+
+save_exclusions() {
+  local tmp="${EXCLUDE_FILE}.tmp.$$"
+  [ -n "$EXCLUDE_FILE" ] || return 1
+  if [ -z "$EXCLUDED" ]; then
+    rm -f -- "$EXCLUDE_FILE" 2>/dev/null
+    return 0
+  fi
+  printf '%s' "$EXCLUDED" >"$tmp" 2>/dev/null || return 1
+  mv -f "$tmp" "$EXCLUDE_FILE"
+}
+
+# Drop the entry an excluded name holds in directory $2, if it is one of ours.
+# A copy left by an environment that cannot link is not, so it stays: removing
+# a real directory is what --force is for.
+unlink_one() {
+  local name="$1" dest="$2/$1"
+  { [ -L "$dest" ] && is_ours "$dest"; } || return 0
+  rm -- "$dest"
+  echo "  remove ${name} (excluded)"
+}
+
 # Remove broken symlinks we own from directory $1. Broken foreign symlinks
 # are left alone.
 prune_dir() {

--- a/rules/no-nonsense-comments.md
+++ b/rules/no-nonsense-comments.md
@@ -31,7 +31,7 @@ reveal it (an upstream bug, a ticket, a hidden side effect).
 
 Comments you do write must sound like a colleague typed them, not an AI: actually invoke the
 `use-conversational-language` skill and follow its conventions — reciting them from memory does
-not count.
+not count. Not installed: write plain prose instead, no dashes and no AI tells.
 
 Bad: `// Overrides default per plan; previously returned null`
 

--- a/rules/write-realistic-texts.md
+++ b/rules/write-realistic-texts.md
@@ -6,7 +6,7 @@ description: Texts other people will read follow the use-conversational-language
 Whenever writing text that other people will read as if the user wrote it — commit messages,
 PR descriptions, review comments, code comments, chat messages or questions for colleagues, and
 similar — you must actually invoke the `use-conversational-language` skill and follow its rules
-— reciting them from memory does not count.
+— reciting them from memory does not count. Not installed: write plain prose instead, no dashes and no AI tells.
 
 Replies to the user in the current session are private agent-user communication, out of scope
 however conversational they sound.

--- a/skills/handover/SKILL.md
+++ b/skills/handover/SKILL.md
@@ -71,6 +71,7 @@ paste-ready as the PR description, and stands alone:
   line per paragraph or bullet.
 - **Plain reviewer-facing wording**, never this skill's vocabulary. Before drafting, actually
   invoke use-conversational-language — reciting its rules from memory does not count.
+  Not installed: write plain prose instead, no dashes and no AI tells.
 
 Sections, skipped only when truly empty:
 

--- a/skills/maintainer-review/SKILL.md
+++ b/skills/maintainer-review/SKILL.md
@@ -128,6 +128,7 @@ merge — comes from the repo's own governing docs, not from here.
   opening line on the round's first comment, naming what the author fixed since the last round,
   which is acknowledgment, not padding. No recap of the PR, no praise padding. Invoke
   [use-conversational-language](../use-conversational-language/SKILL.md) for the wording.
+  Not installed: write plain prose instead, no dashes and no AI tells.
 - **Approvals** — plain, with an empty body. Anything worth saying is a separate comment.
 - **Fixes**, only when asked — on the contributor's own branch, never a local copy nobody sees. The
   go-ahead reaches that branch's push and no further **on the PR**; putting your own checkout back

--- a/skills/refine-pr-review/SKILL.md
+++ b/skills/refine-pr-review/SKILL.md
@@ -82,7 +82,8 @@ pushed back. One table row per comment, resolved and bot rows included for compl
   place on the platform.
 - **Verdict** — `address` / `partial` / `push back`, or `no action` / `resolved earlier` /
   `bot: ignored` / `bot: included`.
-- **Reply** — voiced per **/use-conversational-language** (Developer conversations, author replies);
+- **Reply** — voiced per **/use-conversational-language** (Developer conversations, author replies),
+  or, when it is not installed, plain prose with no dashes and no AI tells;
   canned one-liner for address. Post-fix stance: written as if the accepted changes are already
   made ("did X, kept Y as is because …") — the sheet is pasted after the fixes land. A reply too
   long for a cell goes below the table, referenced by its row number.

--- a/skills/review-code-assistant/SKILL.md
+++ b/skills/review-code-assistant/SKILL.md
@@ -168,6 +168,7 @@ Local text only; write no file unless the user later asks to save it.
   copy); when the comment holds a fence, make the outer one longer, never indent or escape the
   inner fence. Before writing any **Suggested comment**, actually invoke
   **/use-conversational-language** and follow it — reciting its rules from memory does not count.
+  Not installed: write plain prose instead, no dashes and no AI tells.
   That brevity and softness is tone, not hedging: it never lowers the evidence bar from *Grounded,
   not speculative* — stay grounded in *what* to raise, human and brief in *how* you word it.
 - **Order mirrors the diff** so the user can read the PR in one window and copy-paste straight down

--- a/skills/review-ticket/SKILL.md
+++ b/skills/review-ticket/SKILL.md
@@ -144,7 +144,7 @@ scope, the question converts to a handoff.
    A handoff uses the same block format, `### Handoff · <short label>` in place of the number.
    Actually invoke [use-conversational-language](../use-conversational-language/SKILL.md) and
    follow it before writing the questions or handoff messages — reciting its rules from memory
-   does not count; runs with neither skip it. When nothing survived, print only the verdict line
+   does not count; runs with neither skip it. Not installed: write plain prose instead, no dashes and no AI tells. When nothing survived, print only the verdict line
    plus any handoffs.
 
 ```


### PR DESCRIPTION
## What and why

Every skill in `skills/` is linked unconditionally, so someone who does not want one has no way to say so. Deleting the link works until the next daily auto-update puts it back. `./install.sh --exclude <name>` now skips a skill and removes the link we own for it, and the choice sticks.

Nothing changes by default. With no flag every skill is installed exactly as before, so existing installs and new ones are unaffected.

## Decisions worth knowing

The list lives in `<agents-dir>/excluded-skills`, not in the invocation record that `lib/auto-update.sh` replays. The replay re-runs an installer with `--agents-dir` and its target flag only, and the record is a fixed six field tab separated line, so a seventh field would corrupt the reader. A file the replay finds on its own avoids both problems.

`--include <name>` is the way back, mirroring how `--auto-update` undoes `--no-auto-update`.

An excluded name matching no skill in the repo warns and is still stored, so a rename or a typo does not abort the install.

`unlink_one` removes only links we own. A copy left by an environment that cannot link stays, same as everywhere else in the installer, since deleting a real directory is what `--force` is for.

Five skills and two rules told the agent to invoke `use-conversational-language` with no fallback. Excluding it would leave those instructions dangling, so each now names what to do when it is absent. The imperative stays first on purpose: phrasing it as "if available" would read as permission to skip it when it is installed.

## Review guide

`install.sh` and `lib/install-utils.sh` are where judgment matters, in particular the phase two ordering. Excluded entries are unlinked before `prune_dir` runs, because phase one has already broken the chain link by then and prune would report it as pruned rather than as excluded.

The seven doc edits and the README are mechanical, one added sentence each.

## Known gaps

`--exclude` covers skills only. `install-opinionated-rules.sh` shares the helpers but is not wired to them.

Tested by hand on Git Bash: default install, exclude, a no flag run standing in for the replay, include, and an unknown name. No automated test covers the installers today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
